### PR TITLE
Fix missing RuboCop disabled comments in disabled animation file.

### DIFF
--- a/shared/rspec/support/disable_animation.rb
+++ b/shared/rspec/support/disable_animation.rb
@@ -11,6 +11,7 @@ module Rack
     def call(env)
       @status, @headers, @body = @app.call(env)
       return [@status, @headers, @body] unless html?
+
       response = Rack::Response.new([], @status, @headers)
 
       @body.each { |fragment| response.write inject(fragment) }

--- a/shared/rspec/support/disable_animation.rb
+++ b/shared/rspec/support/disable_animation.rb
@@ -53,5 +53,8 @@ module Rack
       EOF
       fragment.gsub(%r{</head>}, disable_animations + '</head>')
     end
+    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Naming/HeredocDelimiterNaming
+    # rubocop:enable Layout/IndentHeredoc:
   end
 end


### PR DESCRIPTION
Fixes #69

## What happened
The codebase spec will fail because we are missing the RuboCop disabled comments on `disabled_animation.rb` file.

## Insight
In this PR, I fix 2 things.
1. Add RuboCop disabled comments after the `inject()` method.
2. Enter a new line after guard clause in `call()` method. (Fix RuboCop `Layout/EmptyLineAfterGuardClause` Rule).

## Proof Of Work
RuboCop should valid on the `disabled_animation.rb` file.