### PR TITLE
Fix missing Redis configuration on Docker compose file. 

### DIFF
--- a/rails_docker/docker-compose.dev.yml
+++ b/rails_docker/docker-compose.dev.yml
@@ -8,3 +8,9 @@ services:
       - POSTGRES_DB=#{app_name}_development
     ports:
       - "5432:5432"
+
+  redis:
+    image: redis:4.0.9
+    container_name: #{app_name}_redis
+    ports:
+      - "6379:6379"

--- a/rails_docker/docker-compose.yml
+++ b/rails_docker/docker-compose.yml
@@ -9,6 +9,12 @@ services:
     ports:
       - "5432:5432"
 
+  redis:
+    image: redis:4.0.9
+    container_name: #{app_name}_redis
+    ports:
+      - "6379:6379"
+
   web:
     build:
       context: .


### PR DESCRIPTION
Fixes #67 

## What happened
 As a description in #67, We can NOT run the `Procfile.dev` file because we are missing the Redis configuration in the Docker compose.
 
## Insight
Just as Redis configuration to the Docker compose file. 

## Proof Of Work
You should start the Redis with `Procfile.dev` file