### PR TITLE
Improve the Dockerfile on Production mode

### DIFF
--- a/rails_docker/Dockerfile
+++ b/rails_docker/Dockerfile
@@ -40,22 +40,30 @@ RUN apt-key add /tmp/yarn-pubkey.gpg && rm /tmp/yarn-pubkey.gpg && \
 # This will have more up-to-date versions of Node.js than the official Debian repositories
 RUN curl -sL https://deb.nodesource.com/setup_"$NODE_VERSION".x | bash -
 
-# Set up the Chrome PPA to install Chrome Headless
-ADD https://dl-ssl.google.com/linux/linux_signing_key.pub /tmp/google-pubkey.gpg
-RUN apt-key add /tmp/google-pubkey.gpg && rm /tmp/google-pubkey.gpg  && \
-    echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google.list
-
 # Install general required core packages, Node JS related packages and Chrome (testing)
 RUN apt-get update -qq && \
-    apt-get install -y --no-install-recommends build-essential libpq-dev nodejs yarn google-chrome-stable && \
+    apt-get install -y --no-install-recommends build-essential libpq-dev nodejs yarn && \
     apt-get install -y --no-install-recommends rsync locales chrpath pkg-config libfreetype6 libfontconfig1 git cmake wget unzip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# Set up the Chrome PPA and install Chrome Headless
+ADD https://dl-ssl.google.com/linux/linux_signing_key.pub /tmp/google-pubkey.gpg
+RUN if [ "$BUILD_ENV" = "test" ]; then \
+      apt-key add /tmp/google-pubkey.gpg && rm /tmp/google-pubkey.gpg  && \
+      echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google.list && \
+      apt-get update -qq && \
+      apt-get install -y --allow-unauthenticated --no-install-recommends google-chrome-stable && \
+      apt-get clean && \
+      rm -rf /var/lib/apt/lists/* ; \
+    fi
+
 # Download and install Chromedriver
-RUN mkdir "$CHROMEDRIVER_DIR" && \
-    wget -q --continue -P $CHROMEDRIVER_DIR "http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip" && \
-    unzip $CHROMEDRIVER_DIR/chromedriver* -d $CHROMEDRIVER_DIR
+RUN if [ "$BUILD_ENV" = "test" ]; then \
+      mkdir "$CHROMEDRIVER_DIR" && \
+      wget -q --continue -P $CHROMEDRIVER_DIR "http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip" && \
+      unzip $CHROMEDRIVER_DIR/chromedriver* -d $CHROMEDRIVER_DIR ; \
+    fi
 
 ENV PATH $CHROMEDRIVER_DIR:$PATH
 
@@ -75,7 +83,11 @@ COPY Gemfile* ./
 # COPY engines/app_auth/lib/ ./engines/app_auth/lib/
 # COPY engines/app_auth/Gemfile engines/app_auth/app_auth.gemspec ./engines/app_auth/
 
-RUN if [ "$BUILD_ENV" = "production" ]; then bundle install --jobs $BUNDLE_JOBS --path $BUNDLE_PATH --without test ; else bundle install --jobs $BUNDLE_JOBS --path $BUNDLE_PATH ; fi
+RUN if [ "$BUILD_ENV" = "production" ]; then \
+      bundle install --jobs $BUNDLE_JOBS --path $BUNDLE_PATH --without development test --deployment ; \
+    else \
+      bundle install --jobs $BUNDLE_JOBS --path $BUNDLE_PATH ; \
+    fi
 
 # Install JS dependencies
 COPY package.json yarn.lock ./


### PR DESCRIPTION
## What happened
I used our Dockeflie template to build the Overblock image and I think we can improve it a bit on Production mode

+ Don't set up Google Chrome on Production mode
+ Don't bundle the `development` gems and add the `--deployment` flag on Production mode

 
## Insight
+ [--deployment flag documentation](https://bundler.io/bundle_install.html#bundle-install)

> The --deployment flag activates a number of deployment- and CI-friendly conventions:
> 
> - Isolate all gems into vendor/bundle (equivalent to --path vendor/bundle)
> - Require an up-to-date Gemfile.lock (equivalent to --frozen)
> - Disable ANSI color output
> - If bundle package was run, do not fetch gems from rubygems.org. Instead, only use gems in the checked in vendor/cache

+ Mina also use the `--deployment` flag when they run bundle on Production https://github.com/mina-deploy/mina/blob/master/tasks/mina/bundler.rb#L6

## Proof Of Work

https://staging.overblock.io/

https://auth-staging.overblock.io/
 