### PR TITLE
Set wait_on_first_by_default to true

### DIFF
--- a/shared/rspec/support/capybara.rb
+++ b/shared/rspec/support/capybara.rb
@@ -44,3 +44,4 @@ end
 
 Capybara.javascript_driver = :chrome
 Capybara.default_max_wait_time = CAPYBARA_TIMEOUT
+Capybara.wait_on_first_by_default = true


### PR DESCRIPTION
## What happened
Set `wait_on_first_by_default` in Capybara configuration to true because when we use first method in Capybara it won't wait for element to render completely if we chain with click method it will click immediately sometimes it cause test to fail, by adding this configuration will make Capybara wait until the first element appear then invoke chain method. 

## Proof Of Work
-- Work in progress --
 