### PR TITLE
Update Rails from 5.1.6 to 5.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ with building complex applications over the years.
 
 ## Get Started
 
+Install ruby and set your local ruby version to `2.5.3`
+
 The main template is `rails_docker`. In order to use it, initialize a new app with the following parameters:
 
 ```

--- a/rails_docker.rb
+++ b/rails_docker.rb
@@ -103,10 +103,6 @@ after_bundle do
   # Shell script to setup the Docker-based development environment
   copy_file 'rails_docker/envsetup', 'bin/envsetup'
 
-  # guard
-  run 'bundle exec spring binstub --all'
-  run 'bundle exec spring binstub rspec'
-
   FileUtils.chmod 0755, 'bin/envsetup'
 
   # Modified README file

--- a/rails_docker/Gemfile.txt
+++ b/rails_docker/Gemfile.txt
@@ -49,7 +49,6 @@ group :development, :test do
   gem 'shoulda-matchers' # Tests common Rails functionalities
   gem 'capybara', '>= 2.15' # Integration testing
   gem 'selenium-webdriver', '3.7.0' # Ruby bindings for Selenium/WebDriver
-  gem 'chromedriver-helper' # Easy installation and use of chromedriver to run system tests with Chrome
   gem 'database_cleaner' # Use Database Cleaner
 
   gem 'pry-rails' # Call 'binding.pry' anywhere in the code to stop execution and get a debugger console

--- a/rails_docker/Gemfile.txt
+++ b/rails_docker/Gemfile.txt
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 ruby '2.5.3'
 
 # Backend
-gem 'rails', '5.1.6' # Latest stable
+gem 'rails', '5.2.3' # Latest stable
 gem 'pg' # Use Postgresql as database
 gem 'puma' # Use Puma as the app server
 gem 'active_model_serializers' # ActiveModel::Serializer implementation and Rails hooks
@@ -11,10 +11,11 @@ gem 'carrierwave-aws' # Use the officially supported AWS-SDK library for S3 stor
 gem 'mini_magick' # A ruby wrapper for ImageMagick or GraphicsMagick command line
 gem 'kaminari' # A Scope & Engine based, clean, powerful, customizable and sophisticated paginator for Rails 3 and 4
 gem 'chronic' # Chronic is a pure Ruby natural language date parser.
-gem 'paranoia', '2.3.1' # Paranoia is a re-implementation of acts_as_paranoid for Rails 3 and Rails 4. Soft-deletion of records
+gem 'paranoia', '2.4.1' # Paranoia is a re-implementation of acts_as_paranoid for Rails 3 and Rails 4. Soft-deletion of records
 gem 'ffaker' # A library for generating fake data such as names, addresses, and phone numbers.
 gem 'fabrication' # Fabrication generates objects in Ruby. Fabricators are schematics for your objects, and can be created as needed anywhere in your app or specs.
 gem 'sidekiq' # background processing for Ruby
+gem 'bootsnap', require: false # Reduces boot times through caching; required in config/boot.rb
 
 # Admin
 gem 'rails_admin'
@@ -30,6 +31,7 @@ gem 'sass-rails' # SASS
 gem 'uglifier'
 
 group :development do
+  gem 'foreman' # Manage Procfile-based applications
   gem 'better_errors' # Better error page for Rails and other Rack apps
   gem 'binding_of_caller' # Retrieve the binding of a method's caller in MRI 1.9.2+
   gem 'awesome_print' # Pretty print your Ruby objects with style -- in full color and with proper indentation
@@ -45,8 +47,9 @@ group :development, :test do
   gem 'rspec-rails' # Rails testing engine
   gem 'guard-rspec' # Auto-run specs
   gem 'shoulda-matchers' # Tests common Rails functionalities
-  gem 'capybara' # Integration testing
+  gem 'capybara', '>= 2.15' # Integration testing
   gem 'selenium-webdriver', '3.7.0' # Ruby bindings for Selenium/WebDriver
+  gem 'chromedriver-helper' # Easy installation and use of chromedriver to run system tests with Chrome
   gem 'database_cleaner' # Use Database Cleaner
 
   gem 'pry-rails' # Call 'binding.pry' anywhere in the code to stop execution and get a debugger console

--- a/shared/app/assets/javascripts/application.js
+++ b/shared/app/assets/javascripts/application.js
@@ -12,3 +12,4 @@
 //
 //= require jquery
 //= require jquery_ujs
+//= require activestorage


### PR DESCRIPTION
## What happened

✅ Upgrade Rails to 5.2.3
 
## Insight

 Upgrading rails and add some libraries that is missing + new from rails 5.2

New gems: 💎 

- bootsnap
- chromedriver-helper

New configuration files: 📁 

- /config/credentials.yml.enc (A replacement for secret.yml)
- /config/master.key
- /config/initializers/content_security_policy.rb
- /config/storage.yml

## Proof Of Work

1. Create the project from the template

2. Start the rails app with
```
bin/envsetup
foreman start -f Procfile.dev
```

![Screen Shot 2562-04-10 at 12 31 22](https://user-images.githubusercontent.com/6965195/55853838-f0804d00-5b8c-11e9-89e0-1eeaff7f1e95.png)

