### PR TITLE
Fix errors when building the docker image

### DIFF
--- a/rails_docker.rb
+++ b/rails_docker.rb
@@ -24,11 +24,6 @@ def source_paths
   Array(super) + [current_directory]
 end
 
-def bundle_version
-  version_string = `bundle --version`
-  version_string.split(' ').last
-end
-
 apply 'lib/config.rb'
 apply 'lib/rspec.rb'
 apply 'lib/test_env.rb'
@@ -42,7 +37,6 @@ copy_file 'rails_docker/Gemfile.txt', 'Gemfile'
 remove_file 'Dockerfile'
 copy_file 'rails_docker/Dockerfile', 'Dockerfile'
 gsub_file 'Dockerfile', '#{app_name}', "#{app_name}"
-gsub_file 'Dockerfile', '#{bundler_version}', "#{bundle_version}"
 
 remove_file 'docker-compose.yml'
 copy_file 'rails_docker/docker-compose.yml', 'docker-compose.yml'

--- a/rails_docker.rb
+++ b/rails_docker.rb
@@ -24,6 +24,11 @@ def source_paths
   Array(super) + [current_directory]
 end
 
+def bundle_version
+  version_string = `bundle --version`
+  version_string.split(' ').last
+end
+
 apply 'lib/config.rb'
 apply 'lib/rspec.rb'
 apply 'lib/test_env.rb'
@@ -37,6 +42,7 @@ copy_file 'rails_docker/Gemfile.txt', 'Gemfile'
 remove_file 'Dockerfile'
 copy_file 'rails_docker/Dockerfile', 'Dockerfile'
 gsub_file 'Dockerfile', '#{app_name}', "#{app_name}"
+gsub_file 'Dockerfile', '#{bundler_version}', "#{bundle_version}"
 
 remove_file 'docker-compose.yml'
 copy_file 'rails_docker/docker-compose.yml', 'docker-compose.yml'

--- a/rails_docker/Dockerfile
+++ b/rails_docker/Dockerfile
@@ -15,7 +15,8 @@ ENV RACK_ENV=$RUBY_ENV \
 ENV APP_HOME=/#{app_name} \
     PORT=80
 
-ENV BUNDLE_GEMFILE=$APP_HOME/Gemfile \
+ENV BUNDLE_VERSION=#{bundler_version} \
+    BUNDLE_GEMFILE=$APP_HOME/Gemfile \
     BUNDLE_JOBS=4 \
     BUNDLE_PATH="/bundle"
 
@@ -83,6 +84,7 @@ COPY Gemfile* ./
 # COPY engines/app_auth/lib/ ./engines/app_auth/lib/
 # COPY engines/app_auth/Gemfile engines/app_auth/app_auth.gemspec ./engines/app_auth/
 
+RUN gem install bundler -v $BUNDLE_VERSION
 RUN if [ "$BUILD_ENV" = "production" ]; then \
       bundle install --jobs $BUNDLE_JOBS --path $BUNDLE_PATH --without development test --deployment ; \
     else \
@@ -99,9 +101,6 @@ COPY . ./
 
 # Compile assets
 RUN bundle exec rails assets:precompile
-
-# Make the init file executable
-RUN chmod +x ./bin/start.sh
 
 EXPOSE $PORT
 

--- a/rails_docker/Dockerfile
+++ b/rails_docker/Dockerfile
@@ -15,8 +15,7 @@ ENV RACK_ENV=$RUBY_ENV \
 ENV APP_HOME=/#{app_name} \
     PORT=80
 
-ENV BUNDLE_VERSION=#{bundler_version} \
-    BUNDLE_GEMFILE=$APP_HOME/Gemfile \
+ENV BUNDLE_GEMFILE=$APP_HOME/Gemfile \
     BUNDLE_JOBS=4 \
     BUNDLE_PATH="/bundle"
 
@@ -84,7 +83,6 @@ COPY Gemfile* ./
 # COPY engines/app_auth/lib/ ./engines/app_auth/lib/
 # COPY engines/app_auth/Gemfile engines/app_auth/app_auth.gemspec ./engines/app_auth/
 
-RUN gem install bundler -v $BUNDLE_VERSION
 RUN if [ "$BUILD_ENV" = "production" ]; then \
       bundle install --jobs $BUNDLE_JOBS --path $BUNDLE_PATH --without development test --deployment ; \
     else \

--- a/rails_docker/Dockerfile
+++ b/rails_docker/Dockerfile
@@ -29,7 +29,7 @@ ENV LANG="en_US.UTF-8" \
     LANGUAGE="en_US:en"
 
 RUN apt-get update -qq && \
-    apt-get install -y --no-install-recommends apt-transport-https curl
+    apt-get install -y --no-install-recommends apt-transport-https curl gnupg
 
 # Add Yarn repository
 ADD https://dl.yarnpkg.com/debian/pubkey.gpg /tmp/yarn-pubkey.gpg


### PR DESCRIPTION
## What happened

✅ Add missing gnupg package in the dockerfile

✅ Fix bundle error when building the image

 
## Insight

#### Gnupg Error

There is an error while installing yarn when building the docker image regarding the missing package.

![Screen Shot 2562-04-10 at 13 56 49](https://user-images.githubusercontent.com/6965195/55863252-5f1cd500-5ba4-11e9-9930-74630f05f789.png)

#### Bundle error

When running bundle install, the bundler version should match the version specified in the gemfile.lock. The version in gemfile.lock is actually comes from local when we new rails project from the template.

![Screen Shot 2562-04-10 at 18 36 59](https://user-images.githubusercontent.com/6965195/55875608-ab294300-5bbf-11e9-90dc-79cf4bd30878.png)

**UPDATED** ☝️ We're agreed to use the bundle version that built in with the ruby. 
  - For ruby 2.5.3 - Bundler version - 1.17.3
  - For ruby 2.6.2 - Bundler version - 1.17.2

Before, there is an env variable that we can set on ruby image - `BUNDLER_VERSION`. But it is removed - https://github.com/docker-library/ruby/pull/255. 

There might be errors on this step if your local bundler is in a different version than the default one. Please recheck your local bundler if that happens.

![Screen Shot 2562-04-12 at 10 43 21](https://user-images.githubusercontent.com/6965195/56010954-d6bb4300-5d0f-11e9-86ee-b82550988cbb.png)

![Screen Shot 2562-04-12 at 10 24 37](https://user-images.githubusercontent.com/6965195/56010311-5e538280-5d0d-11e9-9178-e62e8f3bd693.png)

## Proof Of Work

Building the image passed with no error

```
docker-compose -f docker-compose.test.yml build
```


 