### PR TITLE
Update ruby version from 2.5.3 to 2.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ with building complex applications over the years.
 
 ## Get Started
 
-Install ruby and set your local ruby version to `2.5.3`
+Install ruby and set your local ruby version to `2.6.2`
 
 The main template is `rails_docker`. In order to use it, initialize a new app with the following parameters:
 

--- a/rails_docker.rb
+++ b/rails_docker.rb
@@ -67,7 +67,7 @@ run 'chmod +x bin/test.sh'
 run 'rm -rf test/'
 
 # rvm
-run 'touch .ruby-version && echo 2.5.3 > .ruby-version'
+run 'touch .ruby-version && echo 2.6.2 > .ruby-version'
 run "touch .ruby-gemset && echo #{app_name} > .ruby-gemset"
 
 # Add custom configs

--- a/rails_docker/Dockerfile
+++ b/rails_docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.3-slim
+FROM ruby:2.6.2-slim
 
 ARG RUBY_ENV=development
 ARG NODE_ENV=development

--- a/rails_docker/Gemfile.txt
+++ b/rails_docker/Gemfile.txt
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.5.3'
+ruby '2.6.2'
 
 # Backend
 gem 'rails', '5.2.3' # Latest stable


### PR DESCRIPTION
## What happened

✅ Update ruby version to 2.6.2

## Insight

Update ruby docker image and update the version the Gemfile and .ruby-version

https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/
