### PR TITLE
Update database config

### DIFF
--- a/shared/config/application.yml
+++ b/shared/config/application.yml
@@ -1,4 +1,5 @@
 default: &default
+  DB_NAME: "#{app_name}"
   DB_HOST: "localhost"
   DB_PORT: "5432"
   USERNAME: "postgres"
@@ -8,11 +9,9 @@ default: &default
 
 development:
   <<: *default
-  DB_NAME: "#{app_name}_development"
   SECRET_KEY_BASE: "#{secret_key_base}"
 
 test:
   <<: *default
-  DB_NAME: "#{app_name}_test"
   TEST_RETRY: "0"
   SECRET_KEY_BASE: "#{secret_key_base}"

--- a/shared/config/database.yml
+++ b/shared/config/database.yml
@@ -8,14 +8,14 @@ development:
   host:     <%= ENV['DB_HOST'] %>
   port:     <%= ENV['DB_PORT'] %>
   username: <%= ENV['USERNAME'] %>
-  database: <%= ENV['DB_NAME'] %>
+  database: <%= ENV['DB_NAME'] %>_development
 
 test:
   <<: *default
   host:     <%= ENV['DB_HOST'] %>
   port:     <%= ENV['DB_PORT'] %>
   username: <%= ENV['USERNAME'] %>
-  database: <%= ENV['DB_NAME'] %>
+  database: <%= ENV['DB_NAME'] %>_test
 
 production:
   url: <%= ENV['DATABASE_URL'] %>


### PR DESCRIPTION
## What happened

✅ Update database configurations

 
## Insight

When running `rake db:setup` on local, it should create 2 databases for development and test. Currently it create only one.

![Screen Shot 2562-04-12 at 11 41 25](https://user-images.githubusercontent.com/6965195/56015042-d9bf2f00-5d21-11e9-9995-9b8c966f12ca.png)
![Screen Shot 2562-04-12 at 12 52 54](https://user-images.githubusercontent.com/6965195/56015067-ea6fa500-5d21-11e9-897d-ad922a2d0e51.png)

The problem is in our env, we set
```
development:
  <<: *default
  DB_NAME: "#{app_name}_development"

test:
  <<: *default
  DB_NAME: "#{app_name}_test"
```

So when we run `rake db:setup` on local, it always get the `<name>_development` because we're on the development.

To fix, I move the suffix to `database.yml` instead.

## Proof Of Work

 After:
![Screen Shot 2562-04-12 at 11 40 06](https://user-images.githubusercontent.com/6965195/56015109-0410ec80-5d22-11e9-8bfa-46ffdc9bf846.png)
![Screen Shot 2562-04-12 at 12 52 48](https://user-images.githubusercontent.com/6965195/56015116-07a47380-5d22-11e9-80d0-166415460f09.png)
 