### PR TITLE
Update secret key base configuration due to rails 5.2 changes

### DIFF
--- a/rails_docker/docker-compose.yml
+++ b/rails_docker/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - ASSET_HOST=
       - DEFAULT_HOST=
       - MAILER_SENDER=
-      - SECRET_KEY_BASE=
+      - RAILS_MASTER_KEY=
 
 volumes:
   ruby-bundle:

--- a/shared/config/application.yml
+++ b/shared/config/application.yml
@@ -9,9 +9,7 @@ default: &default
 
 development:
   <<: *default
-  SECRET_KEY_BASE: "#{secret_key_base}"
 
 test:
   <<: *default
   TEST_RETRY: "0"
-  SECRET_KEY_BASE: "#{secret_key_base}"


### PR DESCRIPTION
## What happened

✅ Remove secret key base from env
 
## Insight

Since Rails 5.2, the secret is changed. Right now if we create a new application, the secret key base is set in `config/credentials.yml.enc` where content is encrypted with the `master.key`.

The `credentials.yml.enc`
![Screen Shot 2562-04-12 at 13 55 48](https://user-images.githubusercontent.com/6965195/56017884-bd73c000-5d2a-11e9-98ee-7f4fb8c5f913.png)

The initial content that comes with rails
![Screen Shot 2562-04-12 at 14 00 07](https://user-images.githubusercontent.com/6965195/56018297-e779b200-5d2b-11e9-9aad-be683f004c34.png)

To view/edit the credentials
```
EDITOR="<editor_cli> --wait" rails credentails:edit

# For example, I use vscode. 
EDITOR="code --wait" rails credentails:edit
# But I cannot find a way for RubyMine because it is not support `--wait` option
```
To view/edit, it needs the `config/master.key` to decrypt the file. This file is not committed to the repository and should be kept+managed by ourself.

For production, we can place that key on the server or set by environment `RAILS_MASTER_KEY`.

To access the credentials in the code we can do
```
Rails.application.credentials.secret_key_base
```

More info on credentails: https://guides.rubyonrails.org/security.html#custom-credentials
