### PR TITLE
Add Rack Deflater to reduce response size

### DIFF
--- a/rails_docker.rb
+++ b/rails_docker.rb
@@ -93,6 +93,15 @@ after_bundle do
     "  config.action_mailer.default_url_options = { host: \"localhost\", port: 3000 }"
   end
 
+  # Add Rack Deflater to reduce response size to `config/application.rb`
+  environment do
+    <<~EOT
+      # Compress the responses to reduce the size of html/json controller responses.
+      config.middleware.use Rack::Deflater
+
+    EOT
+  end
+
   # Setup test env
   setup_test_env
 


### PR DESCRIPTION
## What happened

✅ Add Rack deflater to compress responses

 
## Insight

To resolve Issue #85 ⚒ 

https://thoughtbot.com/blog/content-compression-with-rack-deflater 

## Proof Of Work

The configuration added to `config/application.rb`

![Screen Shot 2562-04-12 at 14 52 35](https://user-images.githubusercontent.com/6965195/56021162-f31ca700-5d32-11e9-8eee-ec85ae6b0a45.png)

The page size get reduced 😮 (This is the default rails page)

![Screen Shot 2562-04-12 at 15 00 15](https://user-images.githubusercontent.com/6965195/56021476-b7cea800-5d33-11e9-86c0-574457aed44f.png)

Without deflater:
![Screen Shot 2562-04-12 at 14 58 27](https://user-images.githubusercontent.com/6965195/56021412-9077db00-5d33-11e9-815c-0fca9dcc068e.png)

With deflater:
![Screen Shot 2562-04-12 at 14 57 37](https://user-images.githubusercontent.com/6965195/56021431-9ff72400-5d33-11e9-9bfd-05d47b8ea32e.png)


