### PR TITLE
Enable Bullet to watch for N+1 queries

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -1,0 +1,28 @@
+def setup_bullet
+  environment(nil, env: 'development') do
+    <<~EOT
+      # Configure Bullet gem to detect N+1 queries
+      config.after_initialize do
+        Bullet.enable        = true
+        Bullet.bullet_logger = true
+        Bullet.console       = true
+        Bullet.rails_logger  = true
+        Bullet.add_footer    = true
+      end
+
+    EOT
+  end
+
+  environment(nil, env: 'test') do
+    <<~EOT
+      # Configure Bullet gem to detect N+1 queries
+      config.after_initialize do
+        Bullet.enable                      = true
+        Bullet.bullet_logger               = true
+        Bullet.raise                       = true
+        Bullet.unused_eager_loading_enable = false
+      end
+
+    EOT
+  end
+end

--- a/rails_docker.rb
+++ b/rails_docker.rb
@@ -28,6 +28,7 @@ apply 'lib/config.rb'
 apply 'lib/rspec.rb'
 apply 'lib/test_env.rb'
 apply 'lib/linter.rb'
+apply 'lib/bullet.rb'
 
 # Gemfile
 remove_file 'Gemfile'
@@ -105,6 +106,9 @@ after_bundle do
 
   # Setup test env
   setup_test_env
+
+  # Setup Bullet gem to detect N+1 queries
+  setup_bullet
 
   # rspec
   setup_rspec

--- a/shared/rspec/support/bullet.rb
+++ b/shared/rspec/support/bullet.rb
@@ -1,0 +1,12 @@
+RSpec.configure do |config|
+  if Bullet.enable?
+    config.before(:each) do
+      Bullet.start_request
+    end
+
+    config.after(:each) do
+      Bullet.perform_out_of_channel_notifications if Bullet.notification?
+      Bullet.end_request
+    end
+  end
+end


### PR DESCRIPTION
## What happened

✅ Add Bullet Configurations for `development` and `test`
 
## Insight

Bullet gem is installed but it is not configured. (Issue #20 - Change default configs in test env)

Here I added configurations for development and test. I get the configurations from vcliq project.

## Proof Of Work

### Development

The warning is shown at the bottom of the screen

![Screen Shot 2562-04-17 at 11 52 12](https://user-images.githubusercontent.com/6965195/56265948-2d13f180-6115-11e9-9289-cc99a178d94a.png)

#### Test

The test will failed if there is n+1 queries

![Screen Shot 2562-04-17 at 12 29 47](https://user-images.githubusercontent.com/6965195/56266000-52a0fb00-6115-11e9-853e-cb836bfa7ec9.png)

After fixing the issue, the test is passed

![Screen Shot 2562-04-17 at 12 31 37](https://user-images.githubusercontent.com/6965195/56266058-79f7c800-6115-11e9-8eac-bee32ffb2ed8.png)

 