### PR TITLE
Replace chromedriver-helper with webdrivers

### DIFF
--- a/rails_docker/Dockerfile
+++ b/rails_docker/Dockerfile
@@ -21,9 +21,6 @@ ENV BUNDLE_GEMFILE=$APP_HOME/Gemfile \
 
 ENV NODE_VERSION="8"
 
-ENV CHROMEDRIVER_VERSION="2.39" \
-    CHROMEDRIVER_DIR=/chromedriver
-
 ENV LANG="en_US.UTF-8" \
     LC_ALL="en_US.UTF-8" \
     LANGUAGE="en_US:en"
@@ -57,15 +54,6 @@ RUN if [ "$BUILD_ENV" = "test" ]; then \
       apt-get clean && \
       rm -rf /var/lib/apt/lists/* ; \
     fi
-
-# Download and install Chromedriver
-RUN if [ "$BUILD_ENV" = "test" ]; then \
-      mkdir "$CHROMEDRIVER_DIR" && \
-      wget -q --continue -P $CHROMEDRIVER_DIR "http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip" && \
-      unzip $CHROMEDRIVER_DIR/chromedriver* -d $CHROMEDRIVER_DIR ; \
-    fi
-
-ENV PATH $CHROMEDRIVER_DIR:$PATH
 
 RUN sed -i "s/^#\ \+\(en_US.UTF-8\)/\1/" /etc/locale.gen
 RUN locale-gen en_US.UTF-8

--- a/rails_docker/Gemfile.txt
+++ b/rails_docker/Gemfile.txt
@@ -60,7 +60,7 @@ group :test do
   gem 'rspec-rails' # Rails testing engine
   gem 'rspec-retry' # Retry randomly failing rspec example.
   gem 'capybara', '>= 2.15' # Integration testing
-  gem 'selenium-webdriver', '3.7.0' # Ruby bindings for Selenium/WebDriver
+  gem 'webdrivers' # Run Selenium tests more easily with automatic installation and updates for all supported webdrivers
   gem 'database_cleaner' # Use Database Cleaner
   gem 'shoulda-matchers' # Tests common Rails functionalities
   gem 'json_matchers' # Validate the JSON returned by your Rails JSON APIs

--- a/shared/rspec/support/webdrivers.rb
+++ b/shared/rspec/support/webdrivers.rb
@@ -1,0 +1,24 @@
+Webdrivers::Chromedriver.version = '2.46'
+
+# Configure VCR and WebMock to work with webdrivers
+# https://github.com/titusfortner/webdrivers/wiki/Using-with-VCR-or-WebMock
+if defined?(VCR)
+  VCR.configure do |config|
+    config.ignore_hosts(
+      'chromedriver.storage.googleapis.com',
+      'github.com/mozilla/geckodriver/releases',
+      'selenium-release.storage.googleapis.com',
+      'developer.microsoft.com/en-us/microsoft-edge/tools/webdriver'
+    )
+  end
+end
+
+if defined?(WebMock)
+  allowed_sites = %w[
+    https://chromedriver.storage.googleapis.com
+    https://github.com/mozilla/geckodriver/releases
+    https://selenium-release.storage.googleapis.com
+    https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver
+  ]
+  WebMock.disable_net_connect!(allow_localhost: true, allow: allowed_sites)
+end


### PR DESCRIPTION
## What happened

✅ Replace `chromedriver-helper` with `webdrivers`

## Insight

Now `chromedriver-helper` is deprecated and it is moved to `webdrivers`. On new Rails 6, it has been moved to `webdrivers` too. See https://github.com/rails/rails/pull/35732

I know we haven't include the chromedriver-helper in our gemfile before. But maybe we should? So that we don't need to install `chromedriver` on each machine that we've been working on.

## Proof Of Work

The system test is still runnable.

![Screen Shot 2562-04-17 at 17 35 02](https://user-images.githubusercontent.com/6965195/56281571-2bf3bc00-6137-11e9-83e4-cd9961c404d4.png)

To update, we can set the version in `support/webdrivers.rb`
```
Webdrivers::Chromedriver.version = '2.46'
```

The webdriver is installed at `~/.webdriver` by default. After update the version in the config and run the spec again, it should update the installed binary.

![Screen Shot 2562-04-17 at 18 16 37](https://user-images.githubusercontent.com/6965195/56283869-1a151780-613d-11e9-87e7-92b85507c60e.png)



 