### PR TITLE
Update chrome install script

### DIFF
--- a/rails_docker/Dockerfile
+++ b/rails_docker/Dockerfile
@@ -48,12 +48,12 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists/*
 
 # Set up the Chrome PPA and install Chrome Headless
-ADD https://dl-ssl.google.com/linux/linux_signing_key.pub /tmp/google-pubkey.gpg
 RUN if [ "$BUILD_ENV" = "test" ]; then \
-      apt-key add /tmp/google-pubkey.gpg && rm /tmp/google-pubkey.gpg  && \
-      echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google.list && \
+      wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+      echo 'deb http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google-chrome.list && \
       apt-get update -qq && \
-      apt-get install -y --allow-unauthenticated --no-install-recommends google-chrome-stable && \
+      apt-get install -y --no-install-recommends google-chrome-stable && \
+      rm /etc/apt/sources.list.d/google-chrome.list && \
       apt-get clean && \
       rm -rf /var/lib/apt/lists/* ; \
     fi


### PR DESCRIPTION
## What happened

✅ Fix chrome installation script
 
## Insight

#### Remove `--allow-unauthenticated` option 

I think this is added to resolve this error

```
WARNING: The following packages cannot be authenticated!
  google-chrome-stable
E: There are problems and -y was used without --force-yes
ERROR: Service 'test' failed to build: The command '/bin/sh -c apt-get update -qq &&     apt-get install -y --no-install-recommends build-essential libpq-dev nodejs yarn google-chrome-stable &&     apt-get install -y --no-install-recommends rsync locales chrpath pkg-config libfreetype6 libfontconfig1 git cmake wget unzip &&     apt-get clean &&     rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100
```

@Lahphim and @Yutna face this issue sometimes. I tried to fix the chrome installation without the key by installing chromium or installing another chrome package.
- https://www.hiroom2.com/2017/08/11/debian-9-chromium-en/
- https://linuxconfig.org/google-chrome-web-browser-installation-on-debian-9-stretch-linux
But it doesn't work 😭 

In the end, I decided to remove this option as it has some security risk. Even though we might face that issue sometimes.

#### Change the way to add the key

I move the key down load to be inside the condition so it doesn't download on production

Most of the installation script, I took from https://github.com/SeleniumHQ/docker-selenium/blob/master/NodeChrome/Dockerfile

🗒  **Note:** There is something interesting in the selenium dockerfile. They add option to specify the chrome version. But I didn't look at it now because we didn't have any problem with it.

## Proof Of Work

![Screen Shot 2562-04-19 at 12 11 48](https://user-images.githubusercontent.com/6965195/56412083-3f289800-62ad-11e9-8d7d-cbe9e4038830.png)

 