### PR TITLE
Add package.json template and setup git hook on commit

### DIFF
--- a/rails_docker.rb
+++ b/rails_docker.rb
@@ -75,6 +75,14 @@ run "touch .ruby-gemset && echo #{app_name} > .ruby-gemset"
 # Add custom configs
 setup_config
 
+# Replace default package.json
+remove_file 'package.json'
+copy_file 'rails_docker/package.json', 'package.json'
+gsub_file 'package.json', '#{app_name}', "#{app_name}"
+
+# Git hooks
+directory 'rails_docker/.hooks', '.hooks/'
+
 # Setup Javascript and Stylesheets
 # Remove Turbolinks from `application.js` file
 gsub_file 'app/assets/javascripts/application.js', %r{^\/\/= require turbolinks\n}, ''

--- a/rails_docker/.hooks/commit-msg.sh
+++ b/rails_docker/.hooks/commit-msg.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Get commit message
+commit_message=`cat $1`
+if [[ $commit_message =~ ^[[].{1,}[]].{1,}$ ]]
+# Commit message format is matched
+then
+  exit 0
+# Commit message format is NOT matched
+else
+  echo "Commit message format must match: \"[<User Story ID>] Commit message\""
+  exit 1
+fi

--- a/rails_docker/package.json
+++ b/rails_docker/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "#{app_name}",
+  "scripts": {
+    "lint": "eslint . --color",
+    "lint:fix": "eslint . --color --fix"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "eslint": "6.2.2",
+    "@nimbl3/eslint-config-nimbl3": "2.1.1",
+    "husky": "3.0.4"
+  },
+  "husky": {
+    "hooks": {
+      "commit-msg": "sh .hooks/commit-msg.sh $HUSKY_GIT_PARAMS"
+    }
+  }
+}

--- a/rails_docker/package.json
+++ b/rails_docker/package.json
@@ -1,5 +1,6 @@
 {
   "name": "#{app_name}",
+  "private": true,
   "scripts": {
     "lint": "eslint . --color",
     "lint:fix": "eslint . --color --fix"


### PR DESCRIPTION
## What happened
- Add `package.json` template and copy to generated project.
- Add default package:
  `eslint`: Javascript linter.
  `@nimbl3/eslint-config-nimbl3`: Our javascript linter configuration.
  `husky`: Setup git hook and make it shareable between team member.
- Setup hook for check commit message format to match
```
[Story ID] Commit message
```

## Proof Of Work
- `package.json` is properly generated.
![rails-templates____rails-templates__-___blog_package_json](https://user-images.githubusercontent.com/14077479/63994788-113b4600-cb20-11e9-8521-77ce62d4215c.png)

- Git hook is working. It not allow committing wrong format commit message 
![blog_—_micky_Mickys-MacBook-Pro_—___blog_—_-zsh_—_238×53](https://user-images.githubusercontent.com/14077479/63994669-a984fb00-cb1f-11e9-8212-148768d31c89.png)

 