### PR TITLE
Do not fallback to the Sprockets server when the precompiled asset is missing on Test env

### DIFF
--- a/rails_docker.rb
+++ b/rails_docker.rb
@@ -209,4 +209,13 @@ after_bundle do
       environment.config.set('plugins', plugins);
     EOT
   end
+
+  # Do not fallback to assets pipeline if a precompiled asset is missed.
+  environment(nil, env: 'test') do
+    <<~EOT
+      # Do not fallback to assets pipeline if a precompiled asset is missed.
+      config.assets.compile = false
+
+    EOT
+  end
 end

--- a/rails_docker/Dockerfile
+++ b/rails_docker/Dockerfile
@@ -85,13 +85,11 @@ RUN mkdir -p /usr/local/etc \
 
 # Install Ruby gems
 RUN if [ "$BUILD_ENV" = "production" ]; then \
-  gem install bundler && \
   bundle install --jobs $BUNDLE_JOBS \
                  --path $BUNDLE_PATH \
                  --without development test \
                  --deployment ; \
 else \
-  gem install bundler && \
   bundle install --jobs $BUNDLE_JOBS \
                  --path $BUNDLE_PATH ; \
 fi

--- a/rails_docker/Dockerfile
+++ b/rails_docker/Dockerfile
@@ -85,11 +85,13 @@ RUN mkdir -p /usr/local/etc \
 
 # Install Ruby gems
 RUN if [ "$BUILD_ENV" = "production" ]; then \
+  gem install bundler && \
   bundle install --jobs $BUNDLE_JOBS \
                  --path $BUNDLE_PATH \
                  --without development test \
                  --deployment ; \
 else \
+  gem install bundler && \
   bundle install --jobs $BUNDLE_JOBS \
                  --path $BUNDLE_PATH ; \
 fi

--- a/rails_docker/Gemfile.txt
+++ b/rails_docker/Gemfile.txt
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 ruby '2.6.5'
 
 # Backend
-gem 'rails', '6.0.0' # Latest stable
+gem 'rails', '6.0.1' # Latest stable
 gem 'pg' # Use Postgresql as database
 gem 'puma' # Use Puma as the app server
 gem 'mini_magick' # A ruby wrapper for ImageMagick or GraphicsMagick command line

--- a/shared/rspec/support/assets.rb
+++ b/shared/rspec/support/assets.rb
@@ -1,0 +1,8 @@
+RSpec.configure do |config|
+  config.before(:suite) do
+    # On CI we use Docker and the assets are precompiled (in the Dockerfile) already
+    # On local, usually we run the test on the host machine so have to precompile the assets before running the test
+    `bundle exec rails assets:precompile RAILS_ENV=test NODE_ENV=test` unless ENV['CI']
+  end
+end
+  


### PR DESCRIPTION
## What happened
Do not fallback to the Sprockets server when the precompiled asset is missing on test ENV

 
## Insight
When we use the `image_tag` sometimes we forgot to put the `image extension` like `= image_tag 'logo'` (the correct one should be `= image_tag 'logo.png'`). With that, on the Development and Test ENV everything works (because it fallback to the Sprockets server to get the assets), but when we deploy to Production, it returns a 500 error, technically it shouldn't be like that, it should fail on Test ENV first.

https://stackoverflow.com/questions/29409959/rails-assets-not-precompiling-in-production

![image](https://user-images.githubusercontent.com/11751745/68555120-94e9ab00-045e-11ea-9b82-ff549b6b71ab.png)


## Proof Of Work

<img width="519" alt="Screen Shot 2019-11-10 at 21 54 14" src="https://user-images.githubusercontent.com/11751745/68546155-40b2dc80-0406-11ea-97b5-cab89ae5246b.png">


