### PR TITLE
Do not fallback to the Sprockets server when the precompiled asset is missing on Test env

### DIFF
--- a/rails_docker.rb
+++ b/rails_docker.rb
@@ -209,4 +209,13 @@ after_bundle do
       environment.config.set('plugins', plugins);
     EOT
   end
+
+  # Do not fallback to assets pipeline if a precompiled asset is missed.
+  environment(nil, env: 'test') do
+    <<~EOT
+      # Do not fallback to assets pipeline if a precompiled asset is missed.
+      config.assets.compile = false
+
+    EOT
+  end
 end

--- a/rails_docker/Dockerfile
+++ b/rails_docker/Dockerfile
@@ -85,13 +85,11 @@ RUN mkdir -p /usr/local/etc \
 
 # Install Ruby gems
 RUN if [ "$BUILD_ENV" = "production" ]; then \
-  gem install bundler && \
   bundle install --jobs $BUNDLE_JOBS \
                  --path $BUNDLE_PATH \
                  --without development test \
                  --deployment ; \
 else \
-  gem install bundler && \
   bundle install --jobs $BUNDLE_JOBS \
                  --path $BUNDLE_PATH ; \
 fi

--- a/rails_docker/Dockerfile
+++ b/rails_docker/Dockerfile
@@ -85,11 +85,13 @@ RUN mkdir -p /usr/local/etc \
 
 # Install Ruby gems
 RUN if [ "$BUILD_ENV" = "production" ]; then \
+  gem install bundler && \
   bundle install --jobs $BUNDLE_JOBS \
                  --path $BUNDLE_PATH \
                  --without development test \
                  --deployment ; \
 else \
+  gem install bundler && \
   bundle install --jobs $BUNDLE_JOBS \
                  --path $BUNDLE_PATH ; \
 fi

--- a/shared/rspec/support/assets.rb
+++ b/shared/rspec/support/assets.rb
@@ -1,0 +1,8 @@
+RSpec.configure do |config|
+  config.before(:suite) do
+    # On CI we use Docker and the assets are precompiled (in the Dockerfile) already
+    # On local, usually we run the test on the host machine so have to precompile the assets before running the test
+    `bundle exec rails assets:precompile RAILS_ENV=test NODE_ENV=test` unless ENV['CI']
+  end
+end
+  


### PR DESCRIPTION
## What happened

PR #134 was wrongly merged into the wrong destination so this PR is to bring the same change to `develop`.
 
## Insight

`N/A` 

## Proof Of Work

`N/A`  