### PR TITLE
Remove sidekiq default fake mode for testing line

### DIFF
--- a/shared/rspec/support/sidekiq.rb
+++ b/shared/rspec/support/sidekiq.rb
@@ -1,7 +1,5 @@
 require 'sidekiq/testing'
 
-Sidekiq::Testing.fake!
-
 RSpec.configure do |config|
   config.before(:each) do
     Sidekiq::Worker.clear_all


### PR DESCRIPTION
## What happened
Removed the `Sidekiq::Testing.fake!` line from the sidekiq testing  config file as `fake` testing mode is sidekiq's default testing mode and it should be enabled without explicitly defined it.

 
## Insight
Requiring ` 'sidekiq/testing'` will automatically call `Sidekiq::Testing.fake!`. 

From sidekiq testing wiki [page](https://github.com/mperham/sidekiq/wiki/Testing) 

![Screen Shot 2019-11-11 at 7 03 07 PM](https://user-images.githubusercontent.com/6076762/68585844-ec673580-04b5-11ea-8c1c-146319571e0e.png)


 

## Proof Of Work
N/A
 