### PR TITLE
Add pry-byebug gem for step by step debugging and stack navigation

### DIFF
--- a/rails_docker/Gemfile.txt
+++ b/rails_docker/Gemfile.txt
@@ -43,6 +43,7 @@ group :development, :test do
   gem 'bullet' # help to kill N+1 queries and unused eager loading
   gem 'figaro' # Simple Rails app configuration
   gem 'pry-rails' # Call 'binding.pry' anywhere in the code to stop execution and get a debugger console
+  gem 'pry-byebug' # Step by step debugging and stack navigation in Pry
   gem 'listen', '3.1.5' # Listens to file modifications
   gem 'letter_opener' # Preview mail in the browser instead of sending.
   gem 'sassc-rails' # Gem to generate scss source maps


### PR DESCRIPTION
## What happened
With currently setup for debugging we can not make step by step debugging as well as navigation between stack.

## Insight
Refer this [cheatsheet](https://gist.github.com/palkan/d89757a90cfbeb047c63#debugging-with-pry-byebug) and [pry-byebug](https://github.com/deivid-rodriguez/pry-byebug) for documentation.

## Proof Of Work
![Nov-14-2019 19-11-23](https://user-images.githubusercontent.com/25602820/68856243-a1962980-0712-11ea-9640-6c11a6ad90d1.gif)
