### PR TITLE
Update rubocop.yml and add rubocop-rails

### DIFF
--- a/rails_docker/Gemfile.txt
+++ b/rails_docker/Gemfile.txt
@@ -47,6 +47,8 @@ group :development, :test do
   gem 'letter_opener' # Preview mail in the browser instead of sending.
   gem 'sassc-rails' # Gem to generate scss source maps
   gem 'brakeman', require: false # A static analysis security vulnerability scanner for Ruby on Rails applications
+  gem 'rubocop', require: false
+  gem 'rubocop-rails', require: false
 
   gem 'pronto'
   gem 'pronto-rubocop', require: false

--- a/shared/linters/.rubocop.yml
+++ b/shared/linters/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-rails
+
 AllCops:
   Exclude:
     - 'vendor/**/*'
@@ -11,10 +13,7 @@ AllCops:
     - 'config/**/*'
   TargetRubyVersion: 2.6
 
-Rails:
-  Enabled: true
-
-Documentation:
+Style/Documentation:
   Enabled: false
 
 Metrics/LineLength:
@@ -29,3 +28,6 @@ Metrics/BlockLength:
 
 Style/FrozenStringLiteralComment:
   Enabled: false
+
+Style/FormatStringToken:
+  EnforcedStyle: template

--- a/shared/rspec/rails_helper.rb
+++ b/shared/rspec/rails_helper.rb
@@ -1,5 +1,5 @@
 ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../../config/environment', __FILE__)
+require File.expand_path('../config/environment', __dir__)
 
 require 'spec_helper'
 require 'rspec/rails'

--- a/shared/rspec/support/assets.rb
+++ b/shared/rspec/support/assets.rb
@@ -5,4 +5,3 @@ RSpec.configure do |config|
     `bundle exec rails assets:precompile RAILS_ENV=test NODE_ENV=test` unless ENV['CI']
   end
 end
-  

--- a/shared/rspec/support/capybara.rb
+++ b/shared/rspec/support/capybara.rb
@@ -27,9 +27,7 @@ Capybara.register_driver(:headless_chrome) do |app|
   options.add_argument('no-sandbox')
 
   # Run headless by default unless CHROME_HEADLESS specified
-  # rubocop:disable Performance/RegexpMatch
   options.add_argument('headless') unless ENV['CHROME_HEADLESS'] =~ /^(false|no|0)$/i
-  # rubocop:enable Performance/RegexpMatch
 
   # Disable /dev/shm use in CI
   options.add_argument('disable-dev-shm-usage') if ENV['CI']


### PR DESCRIPTION
## What happened
Update rubocop and fix some warnings

## Insight
- Rails cops were removed from [0.72](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#changes-6), so need to add manually
 - Style::FormatStringToken` `EnforcedStyle` default is `annotated`, change to `template` as we prefer `format('%{greeting}', greeting: 'Hello')` than `format('%<greeting>s', greeting: 'Hello')`
 
## Proof Of Work
No more warnings from rubocop
 