### PR TITLE
Check exit status code rather than stdout message

### DIFF
--- a/shared/rspec/codebase/codebase_spec.rb
+++ b/shared/rspec/codebase/codebase_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 
 describe 'Codebase', codebase: true do
   it 'does not offend Rubocop' do
-    expect(`rubocop --format simple`).to include 'no offenses detected'
+    expect(system('rubocop --format simple', out: :close)).to be_truthy
   end
 
   it 'satisfies Brakeman' do
-    expect(`brakeman -w2`).not_to include '+SECURITY WARNINGS+'
+    expect(system('brakeman -w2', out: :close)).to be_truthy
   end
 
   context 'respond_to blocks' do


### PR DESCRIPTION
## What happened
In the codebase test, we are checking the output of command. For example `expect(`rubocop --format simple`).to include 'no offenses detected'`. Output message are not standard and I think they can change often, whereas exit status code command line applications are standard, and we can be sure that exit status `0` means success.
 
## Insight
 https://www.rubydoc.info/gems/rubocop/0.37.2#Exit_codes

https://apidock.com/ruby/Kernel/system

## Proof Of Work
Tested it  for projects using this template.