### PR TITLE
Use the latest stable web driver version for Selenium as default

### DIFF
--- a/shared/rspec/support/webdrivers.rb
+++ b/shared/rspec/support/webdrivers.rb
@@ -1,5 +1,3 @@
-Webdrivers::Chromedriver.required_version = '2.46'
-
 # Configure VCR and WebMock to work with webdrivers
 # https://github.com/titusfortner/webdrivers/wiki/Using-with-VCR-or-WebMock
 if defined?(VCR)


### PR DESCRIPTION
## What happened
Remove the default version configuration for Chrome Driver

 
## Insight
The webdriver will use the [latest stable version as default](https://github.com/titusfortner/webdrivers#version-pinning) 

![image](https://user-images.githubusercontent.com/11751745/70779945-372ae480-1db7-11ea-8abe-7bd978108c2f.png)

 

## Proof Of Work

 