### PR TITLE
Add missing configurations

### DIFF
--- a/lib/config.rb
+++ b/lib/config.rb
@@ -11,9 +11,9 @@ def setup_config
 end
 
 def add_sidekiq_config
-  insert_into_file 'config/application.rb', after: '# -- all .rb files in that directory are automatically loaded.' do
+  insert_into_file 'config/application.rb', after: %r{config.generators.system_tests.+\n} do
     <<-EOT
-    \n
+    
     # Set the queuing backend to `Sidekiq`
     # 
     # Be sure to have the adapter's gem in your Gemfile

--- a/rails_docker.rb
+++ b/rails_docker.rb
@@ -107,9 +107,9 @@ end
 # Add @nimbl3/eslint-config-nimbl3 plugin to package.json
 insert_into_file 'package.json', before: %r{"version": .+\n} do
   <<~EOT
-      "devDependencies": {
-        "@nimbl3/eslint-config-nimbl3": "2.1.1"
-      },
+    "devDependencies": {
+      "@nimbl3/eslint-config-nimbl3": "2.1.1"
+    },
   EOT
 end
 
@@ -139,8 +139,14 @@ after_bundle do
 
   # Devise configuration
   generate 'devise:install'
-  insert_into_file 'config/environments/development.rb', after: "config.assets.raise_runtime_errors = true\n\n" do
-    "  config.action_mailer.default_url_options = { host: \"localhost\", port: 3000 }"
+  insert_into_file 'config/environments/development.rb', after: %r{config.action_mailer.perform_caching.+\n} do
+    <<-EOT
+
+  config.action_mailer.default_url_options = { 
+    host: ENV.fetch('MAILER_DEFAULT_HOST'), 
+    port: ENV.fetch('MAILER_DEFAULT_PORT')
+  }
+    EOT
   end
 
   # Add Rack Deflater to reduce response size to `config/application.rb`


### PR DESCRIPTION
## What happened

✅ Bring back some missing configurations
 
## Insight

There are some missing configurations but the script is passed because it is just the warnings from Thor.

![Screen Shot 2563-02-10 at 16 54 41](https://user-images.githubusercontent.com/6965195/74141097-e144b280-4c28-11ea-9b4d-8a870571628e.png)

![Screen Shot 2563-02-10 at 16 54 12](https://user-images.githubusercontent.com/6965195/74141105-e3a70c80-4c28-11ea-8fa0-5ceccf6d3a69.png)

I'm just fixing it for now. Later we can add more tests to catch these cases.

## Proof Of Work

Final files:

1. `application.rb`

![Screen Shot 2563-02-10 at 16 55 51](https://user-images.githubusercontent.com/6965195/74141224-1a7d2280-4c29-11ea-9c48-3f1cd8625eee.png)

2. `development.rb`

![Screen Shot 2563-02-10 at 16 56 07](https://user-images.githubusercontent.com/6965195/74141233-1e10a980-4c29-11ea-9cac-4a57b71b47e2.png)
 