### PR TITLE
Upgrade Postgresql redis image

### DIFF
--- a/rails_docker/docker-compose.dev.yml.tt
+++ b/rails_docker/docker-compose.dev.yml.tt
@@ -2,7 +2,7 @@ version: '3.2'
 
 services:
   db:
-    image: postgres:10.1
+    image: postgres:12.1
     container_name: <%= APP_NAME %>_db
     environment:
       - POSTGRES_DB=<%= APP_NAME %>_development
@@ -10,7 +10,7 @@ services:
       - "5432:5432"
 
   redis:
-    image: redis:4.0.9
+    image: redis:5.0.7
     container_name: <%= APP_NAME %>_redis
     ports:
       - "6379:6379"

--- a/rails_docker/docker-compose.test.yml.tt
+++ b/rails_docker/docker-compose.test.yml.tt
@@ -2,7 +2,7 @@ version: '3.2'
 
 services:
   db:
-    image: postgres:10.1
+    image: postgres:12.1
     container_name: <%= APP_NAME %>_db
     environment:
       - POSTGRES_DB=<%= APP_NAME %>_test
@@ -10,7 +10,7 @@ services:
       - "5432"
 
   redis:
-    image: redis:4.0.9
+    image: redis:5.0.7
     container_name: <%= APP_NAME %>_redis
     ports:
       - "6379"

--- a/rails_docker/docker-compose.yml.tt
+++ b/rails_docker/docker-compose.yml.tt
@@ -2,7 +2,7 @@ version: '3.2'
 
 services:
   db:
-    image: postgres:10.1
+    image: postgres:12.1
     container_name: <%= APP_NAME %>_db
     environment:
       - POSTGRES_DB=<%= APP_NAME %>_production
@@ -10,7 +10,7 @@ services:
       - "5432:5432"
 
   redis:
-    image: redis:4.0.9
+    image: redis:5.0.7
     container_name: <%= APP_NAME %>_redis
     ports:
       - "6379:6379"

--- a/shared/config/application.yml.tt
+++ b/shared/config/application.yml.tt
@@ -2,7 +2,7 @@ default: &default
   DB_NAME: "<%= APP_NAME %>"
   DB_HOST: "localhost"
   DB_PORT: "5432"
-  USERNAME: "postgres"
+  DB_USERNAME: "postgres"
   MAILER_DEFAULT_HOST: "localhost"
   MAILER_DEFAULT_PORT: "3000"
   MAILER_SENDER: "Test <noreply@nimblehq.co>"

--- a/shared/config/database.yml
+++ b/shared/config/database.yml
@@ -7,14 +7,14 @@ development:
   <<: *default
   host:     <%= ENV['DB_HOST'] %>
   port:     <%= ENV['DB_PORT'] %>
-  username: <%= ENV['USERNAME'] %>
+  username: <%= ENV['DB_USERNAME'] %>
   database: <%= ENV['DB_NAME'] %>_development
 
 test:
   <<: *default
   host:     <%= ENV['DB_HOST'] %>
   port:     <%= ENV['DB_PORT'] %>
-  username: <%= ENV['USERNAME'] %>
+  username: <%= ENV['DB_USERNAME'] %>
   database: <%= ENV['DB_NAME'] %>_test
 
 production:


### PR DESCRIPTION
## What happened
- Upgrade Postgresql image to 12.1
- Upgrade Redis to 5.0.7
- Minor improvement the DB configuration, changing the USERNAME to **DB_USERNAME**

![image](https://user-images.githubusercontent.com/11751745/74306348-e58dde80-4d94-11ea-8240-d8d1a49af09e.png)


 
## Insight
As the current Postgresql and Redis version is too old in this template, we should upgrade it to the latest version

Heroku also supports PostgreSQL 12 and Redis 5 by default already.
- https://devcenter.heroku.com/articles/heroku-postgresql
- https://devcenter.heroku.com/articles/heroku-redis

![image](https://user-images.githubusercontent.com/11751745/74306268-abbcd800-4d94-11ea-8932-80c9bb2899e1.png)

![image](https://user-images.githubusercontent.com/11751745/74306291-ba0af400-4d94-11ea-8601-502f662a24d5.png)

 
 