### PR TITLE
Add zeitwerk checking to codebase spec

### DIFF
--- a/spec/codebase/codebase_spec.rb
+++ b/spec/codebase/codebase_spec.rb
@@ -9,6 +9,10 @@ describe 'Codebase', codebase: true do
     expect(`brakeman -w2`).not_to include '+SECURITY WARNINGS+'
   end
 
+  it 'does NOT break zeitwerk loading' do
+    expect(`bundle exec rake zeitwerk:check`).to include 'All is good!'
+  end
+
   context 'respond_to blocks' do
     it 'does not contain respond_to blocks' do
       find_results = `grep -r 'respond_to do' app/`


### PR DESCRIPTION
## What happened
- We faced the problem in one project as everything works well on `development` environment, but when we deploy to UAT (production mode) it failed.

```ruby
 `/bundle/ruby/2.6.0/gems/zeitwerk-2.2.1/lib/zeitwerk/loader.rb:351:in const_get': uninitialized constant ... (NameError)
```
- Rails 6 is using zeitwerk loader as default, In this PR, I added `zeitwerk` loading checking to our codebase spec to make sure our code will be works on development as well as production.

```
bundle exec rake zeitwerk:check
```
## Insight
N/A

## Proof Of Work

- Should pass all tests
 