### PR TITLE
Enable single template application

### DIFF
--- a/.template/addons/docker/template.rb
+++ b/.template/addons/docker/template.rb
@@ -1,4 +1,4 @@
-use_source_paths [__dir__]
+use_source_path __dir__
 
 template 'Dockerfile.tt'
 template 'docker-compose.dev.yml.tt'

--- a/.template/addons/semaphore/template.rb
+++ b/.template/addons/semaphore/template.rb
@@ -1,4 +1,4 @@
-use_source_paths [__dir__]
+use_source_path __dir__
 
 directory '.semaphore'
 

--- a/.template/spec/base/config/environments/development_spec.rb
+++ b/.template/spec/base/config/environments/development_spec.rb
@@ -22,7 +22,7 @@ describe 'config/environments/development.rb' do
   def mailer_default_url_config
     <<~EOT
       config.action_mailer.default_url_options = {
-        host: ENV.fetch('MAILER_DEFAULT_HOST'), 
+        host: ENV.fetch('MAILER_DEFAULT_HOST'),
         port: ENV.fetch('MAILER_DEFAULT_PORT')
       }
     EOT

--- a/.template/spec/base/config/environments/production_spec.rb
+++ b/.template/spec/base/config/environments/production_spec.rb
@@ -14,7 +14,7 @@ describe 'config/environments/production.rb' do
   def mailer_default_url_config
     <<~EOT
       config.action_mailer.default_url_options = {
-        host: ENV.fetch('MAILER_DEFAULT_HOST'), 
+        host: ENV.fetch('MAILER_DEFAULT_HOST'),
         port: ENV.fetch('MAILER_DEFAULT_PORT')
       }
     EOT

--- a/.template/spec/base/config/environments/test_spec.rb
+++ b/.template/spec/base/config/environments/test_spec.rb
@@ -14,7 +14,7 @@ describe 'config/environments/test.rb' do
   def mailer_default_url_config
     <<~EOT
       config.action_mailer.default_url_options = {
-        host: ENV.fetch('MAILER_DEFAULT_HOST'), 
+        host: ENV.fetch('MAILER_DEFAULT_HOST'),
         port: ENV.fetch('MAILER_DEFAULT_PORT')
       }
     EOT

--- a/.template/variants/api/template.rb
+++ b/.template/variants/api/template.rb
@@ -1,3 +1,3 @@
-use_source_paths [__dir__]
+use_source_path __dir__
 
 apply 'app/template.rb'

--- a/.template/variants/web/Gemfile.rb
+++ b/.template/variants/web/Gemfile.rb
@@ -6,7 +6,7 @@ end
 
 insert_into_file 'Gemfile', after: %r{gem 'pundit'.*\n} do
   <<~EOT
-  
+
     # Assets
     gem 'webpacker', '4.0' # Transpile app-like JavaScript
     gem 'sass-rails' # SASS

--- a/.template/variants/web/app/template.rb
+++ b/.template/variants/web/app/template.rb
@@ -3,9 +3,9 @@ directory 'app/javascript'
 
 insert_into_file 'app/javascript/packs/application.js', after: %r{require\("channels"\)\n} do
   <<~EOT
-  
+
     import 'translations/translations';
-    
+
     import 'initializers/';
     import 'screens/';
   EOT

--- a/.template/variants/web/template.rb
+++ b/.template/variants/web/template.rb
@@ -1,5 +1,5 @@
 def apply_web_variant!
-  use_source_paths [__dir__]
+  use_source_path __dir__
 
   copy_file '.eslintignore'
   copy_file '.eslintrc'
@@ -16,7 +16,7 @@ def apply_web_variant!
   remove_turbolinks
 
   after_bundle do
-    use_source_paths [__dir__]
+    use_source_path __dir__
 
     # Fix the default rails template that does not put trailing commas
     run 'yarn run lint --fix'

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ To apply the template on an existing application, run following rails command:
 ```
 rails app:template LOCATION=https://raw.githubusercontent.com/nimblehq/rails-templates/master/template.rb
 
+# To apply on an api application
+rails app:template LOCATION=https://raw.githubusercontent.com/nimblehq/rails-templates/master/template.rb API=true
+
 # To apply a specific addon
 rails app:template LOCATION=https://raw.githubusercontent.com/nimblehq/rails-templates/master/template.rb ADDON=<addon name>
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ with building complex applications over the years.
 - Install ruby and set your local ruby version to `2.6.5`
 - Install rails > `6.0.0`, recommended version `6.0.1`
 
-The main template is `rails_docker`. In order to use it, initialize a new app with the following parameters:
+### Use the template
+
+In order to use the template, initialize a new app with the following parameters:
 
 ```
 rails new <app_name> -m https://raw.githubusercontent.com/nimblehq/rails-templates/master/template.rb
@@ -28,11 +30,17 @@ rails new <app_name> -m https://raw.githubusercontent.com/nimblehq/rails-templat
 Supported template options:
 - `--api` - create an api-only application
 
-To apply a single template
+To apply the template on an existing application, run following rails command:
 
 ```
 rails app:template LOCATION=https://raw.githubusercontent.com/nimblehq/rails-templates/master/template.rb
+
+# To apply a specific addon
+rails app:template LOCATION=https://raw.githubusercontent.com/nimblehq/rails-templates/master/template.rb ADDON=<addon name>
 ```
+
+Available Addons:
+- `docker`
 
 Read more about Rails Application Template in the [official Rails Guides](https://guides.rubyonrails.org/rails_application_templates.html).
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ with building complex applications over the years.
 
 ## Get Started
 
-Install ruby and set your local ruby version to `2.6.5`
+### Requirements
+
+- Install ruby and set your local ruby version to `2.6.5`
+- Install rails > `6.0.0`, recommended version `6.0.1`
 
 The main template is `rails_docker`. In order to use it, initialize a new app with the following parameters:
 
@@ -24,6 +27,12 @@ rails new <app_name> -m https://raw.githubusercontent.com/nimblehq/rails-templat
 
 Supported template options:
 - `--api` - create an api-only application
+
+To apply a single template
+
+```
+rails app:template LOCATION=https://raw.githubusercontent.com/nimblehq/rails-templates/master/template.rb
+```
 
 Read more about Rails Application Template in the [official Rails Guides](https://guides.rubyonrails.org/rails_application_templates.html).
 

--- a/template.rb
+++ b/template.rb
@@ -13,7 +13,7 @@ API_VARIANT = options[:api]
 WEB_VARIANT = !options[:api]
 
 def apply_template!
-  use_source_paths [current_directory]
+  use_source_path __dir__
 
   delete_test_folder
 
@@ -39,7 +39,7 @@ def apply_template!
   apply '.gitignore.rb'
 
   after_bundle do
-    use_source_paths [current_directory]
+    use_source_path __dir__
 
     # Stop the spring before using the generators as it might hang for a long time
     # Issue: https://github.com/rails/spring/issues/486
@@ -64,12 +64,8 @@ def source_paths
 end
 
 # Prepend the required paths to the source paths to make the template files in those paths available
-def use_source_paths(source_paths)
-  @source_paths.unshift(*source_paths)
-end
-
-def current_directory
-  @current_directory ||= __FILE__ =~ %r{\Ahttps?://} ? remote_repository : __dir__
+def use_source_path(source_path)
+  @source_paths.unshift(source_path)
 end
 
 def remote_repository
@@ -94,4 +90,14 @@ def delete_test_folder
   FileUtils.rm_rf('test')
 end
 
-apply_template!
+# Setup the template root path
+# If the template file is the url, clone the repo to the tmp directory
+template_root = __FILE__ =~ %r{\Ahttps?://} ? remote_repository : __dir__
+use_source_path template_root
+
+if ENV['ADDON']
+  apply ".template/addons/#{ENV['ADDON']}/template.rb"
+else
+  apply_template!
+end
+

--- a/template.rb
+++ b/template.rb
@@ -13,9 +13,6 @@ API_VARIANT = options[:api]
 WEB_VARIANT = !options[:api]
 
 def apply_template!(template_root)
-  p '*'*10
-  p template_root
-  p '*'*10
   use_source_path template_root
 
   delete_test_folder
@@ -42,10 +39,6 @@ def apply_template!(template_root)
   apply '.gitignore.rb'
 
   after_bundle do
-    p '='*10
-    p template_root
-    p '='*10
-
     use_source_path template_root
 
     # Stop the spring before using the generators as it might hang for a long time
@@ -67,14 +60,11 @@ end
 
 # Set Thor::Actions source path for looking up the files
 def source_paths
-  @source_paths ||= []
+  @source_paths
 end
 
 # Prepend the required paths to the source paths to make the template files in those paths available
 def use_source_path(source_path)
-  p @source_paths
-  p source_path
-
   @source_paths.unshift(source_path)
 end
 
@@ -100,14 +90,12 @@ def delete_test_folder
   FileUtils.rm_rf('test')
 end
 
+# Init the source path
+@source_paths ||= []
 # Setup the template root path
 # If the template file is the url, clone the repo to the tmp directory
 template_root = __FILE__ =~ %r{\Ahttps?://} ? remote_repository : __dir__
 use_source_path template_root
-
-p '='*10
-p template_root
-p '='*10
 
 if ENV['ADDON']
   apply ".template/addons/#{ENV['ADDON']}/template.rb"

--- a/template.rb
+++ b/template.rb
@@ -9,8 +9,8 @@ RUBY_VERSION = '2.6.5'
 POSTGRES_VERSION = '12.1'
 REDIS_VERSION = '5.0.7'
 # Variants
-API_VARIANT = options[:api]
-WEB_VARIANT = !options[:api]
+API_VARIANT = options[:api] || ENV['API'] == 'true'
+WEB_VARIANT = !API_VARIANT
 
 def apply_template!(template_root)
   use_source_path template_root

--- a/template.rb
+++ b/template.rb
@@ -98,7 +98,11 @@ template_root = __FILE__ =~ %r{\Ahttps?://} ? remote_repository : __dir__
 use_source_path template_root
 
 if ENV['ADDON']
-  apply ".template/addons/#{ENV['ADDON']}/template.rb"
+  addon_template_path = ".template/addons/#{ENV['ADDON']}/template.rb"
+
+  abort 'This addon is not supported' unless File.exist?(addon_template_path)
+
+  apply addon_template_path
 else
   apply_template!(template_root)
 end

--- a/template.rb
+++ b/template.rb
@@ -12,8 +12,11 @@ REDIS_VERSION = '5.0.7'
 API_VARIANT = options[:api]
 WEB_VARIANT = !options[:api]
 
-def apply_template!
-  use_source_path __dir__
+def apply_template!(template_root)
+  p '*'*10
+  p template_root
+  p '*'*10
+  use_source_path template_root
 
   delete_test_folder
 
@@ -39,7 +42,11 @@ def apply_template!
   apply '.gitignore.rb'
 
   after_bundle do
-    use_source_path __dir__
+    p '='*10
+    p template_root
+    p '='*10
+
+    use_source_path template_root
 
     # Stop the spring before using the generators as it might hang for a long time
     # Issue: https://github.com/rails/spring/issues/486
@@ -65,6 +72,9 @@ end
 
 # Prepend the required paths to the source paths to make the template files in those paths available
 def use_source_path(source_path)
+  p @source_paths
+  p source_path
+
   @source_paths.unshift(source_path)
 end
 
@@ -95,9 +105,12 @@ end
 template_root = __FILE__ =~ %r{\Ahttps?://} ? remote_repository : __dir__
 use_source_path template_root
 
+p '='*10
+p template_root
+p '='*10
+
 if ENV['ADDON']
   apply ".template/addons/#{ENV['ADDON']}/template.rb"
 else
-  apply_template!
+  apply_template!(template_root)
 end
-

--- a/template.rb
+++ b/template.rb
@@ -4,10 +4,10 @@ require 'shellwords'
 APP_NAME = app_name
 # Transform the app name from slug to human-readable name e.g. nimble-web -> Nimble
 APP_NAME_HUMANIZED = app_name.split(/[-_]/).map(&:capitalize).join(' ').gsub(/ Web$/, '')
-DOCKER_IMAGE = "nimblehq/#{APP_NAME}"
-RUBY_VERSION = '2.6.5'
-POSTGRES_VERSION = '12.1'
-REDIS_VERSION = '5.0.7'
+DOCKER_IMAGE = "nimblehq/#{APP_NAME}".freeze
+RUBY_VERSION = '2.6.5'.freeze
+POSTGRES_VERSION = '12.1'.freeze
+REDIS_VERSION = '5.0.7'.freeze
 # Variants
 API_VARIANT = options[:api] || ENV['API'] == 'true'
 WEB_VARIANT = !API_VARIANT


### PR DESCRIPTION
## What happened

- Allow to apply single addon onto an existing application
 
## Insight

The path needs to be fixed to make it work remotely.

To apply a single template, we need to call it through the main template as the repo needs to be cloned before it is templating.

```
rails app:template LOCATION=<template_url> ADDON=<addon name>
```

For an api application, there are no option provided like rails new command. So instead, you can pass `API` variable.

```
rails app:template LOCATION=<template_url> API=true
```

## Proof Of Work

You can try create/update the application with the template on this branch

```
rails new <app_name> -m https://raw.githubusercontent.com/nimblehq/rails-templates/feature/apply-single-template/template.rb

rails app:template LOCATION=https://raw.githubusercontent.com/nimblehq/rails-templates/feature/apply-single-template/template.rb

rails app:template LOCATION=https://raw.githubusercontent.com/nimblehq/rails-templates/feature/apply-single-template/template.rb API=true

rails app:template LOCATION=https://raw.githubusercontent.com/nimblehq/rails-templates/feature/apply-single-template/template.rb ADDON=docker
```
 