### PR TITLE
Add support old applications to apply the template

### DIFF
--- a/.template/lib/template/errors.rb
+++ b/.template/lib/template/errors.rb
@@ -1,0 +1,21 @@
+module Template
+  class Errors
+    delegate :empty?, to: :errors
+
+    def initialize
+      @errors = []
+    end
+
+    def add(error_message)
+      errors << error_message
+    end
+
+    def to_s
+      errors.join("#{'-' * 80}\n")
+    end
+
+    private
+
+    attr_reader :errors
+  end
+end

--- a/.template/variants/web/app/template.rb
+++ b/.template/variants/web/app/template.rb
@@ -1,8 +1,7 @@
 # Javascript
+directory 'app/javascript'
 
-if Dir.exist?('app/javascript')
-  directory 'app/javascript'
-
+if File.exist?('app/javascript/packs/application.js')
   insert_into_file 'app/javascript/packs/application.js', after: %r{require\("channels"\)\n} do
     <<~EOT
 
@@ -12,6 +11,14 @@ if Dir.exist?('app/javascript')
       import 'screens/';
     EOT
   end
+else
+  @template_errors.add <<~EOT
+    Cannot import the dependencies to `app/javascript/packs/application.js`
+    Content: import 'translations/translations';
+
+             import 'initializers/';
+             import 'screens/';
+  EOT
 end
 
 # Stylesheets

--- a/.template/variants/web/app/template.rb
+++ b/.template/variants/web/app/template.rb
@@ -1,14 +1,17 @@
 # Javascript
-directory 'app/javascript'
 
-insert_into_file 'app/javascript/packs/application.js', after: %r{require\("channels"\)\n} do
-  <<~EOT
+if Dir.exist?('app/javascript')
+  directory 'app/javascript'
 
-    import 'translations/translations';
+  insert_into_file 'app/javascript/packs/application.js', after: %r{require\("channels"\)\n} do
+    <<~EOT
 
-    import 'initializers/';
-    import 'screens/';
-  EOT
+      import 'translations/translations';
+
+      import 'initializers/';
+      import 'screens/';
+    EOT
+  end
 end
 
 # Stylesheets
@@ -24,6 +27,13 @@ inject_into_class 'app/controllers/application_controller.rb', 'ApplicationContr
 end
 
 # Views
-gsub_file 'app/views/layouts/application.html.erb', /<html>/ do
-  "<html lang='<%= I18n.locale %>'>"
+if File.exist?('app/views/layouts/application.html.erb')
+  gsub_file 'app/views/layouts/application.html.erb', /<html>/ do
+    "<html lang='<%= I18n.locale %>'>"
+  end
+else
+  @template_errors.add <<~EOT
+    Cannot insert the lang attribute into html tag into `app/views/layouts/application.html.erb`
+    Content: <html lang='<%= I18n.locale %>'>
+  EOT
 end

--- a/.template/variants/web/template.rb
+++ b/.template/variants/web/template.rb
@@ -27,8 +27,24 @@ def apply_web_variant!
 end
 
 def remove_turbolinks
-  gsub_file('app/views/layouts/application.html.erb', %r{, 'data-turbolinks-track': 'reload'}, '')
-  gsub_file('app/javascript/packs/application.js', %r{^require\(\"turbolinks\"\).start\(\)\n}, '')
+  if File.exist?('app/views/layouts/application.html.erb')
+    gsub_file('app/views/layouts/application.html.erb', %r{, 'data-turbolinks-track': 'reload'}, '')
+  else
+    @template_errors.add <<~EOT
+      Cannot Remove turbolinks from application.html.erb file
+      Content: 'data-turbolinks-track': 'reload'
+    EOT
+  end
+  
+  if File.exist?('app/javascript/packs/application.js')
+    gsub_file('app/javascript/packs/application.js', %r{^require\(\"turbolinks\"\).start\(\)\n}, '')
+  else
+    @template_errors.add <<~EOT
+      Cannot Remove turbolinks from packs/application.js
+      Content: require("turbolinks").start()
+    EOT
+  end
+
   gsub_file('package.json', %r{"turbolinks": .+\n}, '')
 end
 

--- a/.template/variants/web/template.rb
+++ b/.template/variants/web/template.rb
@@ -31,7 +31,7 @@ def remove_turbolinks
     gsub_file('app/views/layouts/application.html.erb', %r{, 'data-turbolinks-track': 'reload'}, '')
   else
     @template_errors.add <<~EOT
-      Cannot Remove turbolinks from application.html.erb file
+      Cannot Remove turbolinks from `application.html.erb` file
       Content: 'data-turbolinks-track': 'reload'
     EOT
   end
@@ -40,7 +40,7 @@ def remove_turbolinks
     gsub_file('app/javascript/packs/application.js', %r{^require\(\"turbolinks\"\).start\(\)\n}, '')
   else
     @template_errors.add <<~EOT
-      Cannot Remove turbolinks from packs/application.js
+      Cannot Remove turbolinks from `app/javascript/packs/application.js`
       Content: require("turbolinks").start()
     EOT
   end

--- a/template.rb
+++ b/template.rb
@@ -90,12 +90,29 @@ def delete_test_folder
   FileUtils.rm_rf('test')
 end
 
+def print_error_message
+  puts <<~EOT
+    #{'=' * 80}
+
+    There are some errors when templating the application, Please fix them manually:
+
+    #{@template_errors}
+
+    #{'=' * 80}
+  EOT
+end
+
 # Init the source path
 @source_paths ||= []
+
 # Setup the template root path
 # If the template file is the url, clone the repo to the tmp directory
 template_root = __FILE__ =~ %r{\Ahttps?://} ? remote_repository : __dir__
 use_source_path template_root
+
+# Init the template error
+require_relative '.template/lib/template/errors'
+@template_errors = Template::Errors.new
 
 if ENV['ADDON']
   addon_template_path = ".template/addons/#{ENV['ADDON']}/template.rb"
@@ -106,3 +123,5 @@ if ENV['ADDON']
 else
   apply_template!(template_root)
 end
+
+print_error_message unless @template_errors.empty?

--- a/template.rb
+++ b/template.rb
@@ -97,7 +97,6 @@ def print_error_message
     There are some errors when templating the application, Please fix them manually:
 
     #{@template_errors}
-
     #{'=' * 80}
   EOT
 end
@@ -110,8 +109,8 @@ end
 template_root = __FILE__ =~ %r{\Ahttps?://} ? remote_repository : __dir__
 use_source_path template_root
 
-# Init the template error
-require_relative '.template/lib/template/errors'
+# Init the template errors
+require "#{template_root}/.template/lib/template/errors"
 @template_errors = Template::Errors.new
 
 if ENV['ADDON']


### PR DESCRIPTION
## What happened

✅ There are some issue for apply the template on existing application that the javascripts structure might be different or it is using the slim template

## Insight

To fix, now I just displaying list of the errors, so that we know where should we fix.

I checked for the old application There are 2 problems I found:

1. Javascript structure

    The old project might have the javascript on `/app/assets/javascripts`, the new one is on `app/javascripts`

2. Html template

    The new project is init with the `erb`, the old one, usually in the `slim`. So there will be small problem on applying the template. (But very small as those project should have it set already)

So in these case, the errors will be displayed and we need to work on it manually.

## Proof Of Work

Try apply with

```
rails app:template LOCATION=https://raw.githubusercontent.com/nimblehq/rails-templates/chore/fix-file-errors/template.rb
```

If there are errors, the error message will be displayed at the end

![Screen Shot 2563-03-13 at 16 34 19](https://user-images.githubusercontent.com/6965195/76608625-87e1e300-6548-11ea-9490-05b5adbbd165.png)


 