### PR TITLE
Add script to copy the gem dependencies for building docker image

### DIFF
--- a/.template/addons/docker/.dockerignore.tt
+++ b/.template/addons/docker/.dockerignore.tt
@@ -4,6 +4,7 @@
 .semaphore-cache
 log/
 tmp/
+!tmp/docker
 coverage/
 <%- if WEB_VARIANT -%>
 node_modules/

--- a/.template/addons/docker/Dockerfile.tt
+++ b/.template/addons/docker/Dockerfile.tt
@@ -65,14 +65,6 @@ RUN if [ "$BUILD_ENV" = "test" ]; then \
 <%- end -%>
 WORKDIR $APP_HOME
 
-# Move gemfile into place
-COPY Gemfile* ./
-
-# if the application uses Rails engines, copy each engine lib/, Gemfile and .gemspec files
-# Example:
-# COPY engines/app_auth/lib/ ./engines/app_auth/lib/
-# COPY engines/app_auth/Gemfile engines/app_auth/app_auth.gemspec ./engines/app_auth/
-
 # Skip installing gem documentation
 RUN mkdir -p /usr/local/etc \
 	&& { \
@@ -85,6 +77,9 @@ RUN mkdir -p /usr/local/etc \
 		echo 'install: --no-document'; \
 		echo 'update: --no-document'; \
 	} >> /usr/local/etc/gemrc
+
+# Copy all denpendencies from app and engines into tmp/docker to install
+COPY tmp/docker ./
 
 # Install Ruby gems
 RUN gem install bundler && \
@@ -107,6 +102,9 @@ RUN yarn install --network-timeout 100000
 # Copying the app files must be placed after the dependencies setup
 # since the app files always change thus cannot be cached
 COPY . ./
+
+# Remove tmp/docker in the final image
+RUN rm -rf tmp/docker
 
 <%- if WEB_VARIANT -%>
 # Compile assets

--- a/.template/addons/semaphore/.semaphore/promotion-production.yml.tt
+++ b/.template/addons/semaphore/.semaphore/promotion-production.yml.tt
@@ -24,6 +24,7 @@ blocks:
       jobs:
         - name: Build
           commands:
+            - bin/docker-prepare
             - docker-compose build
             - docker-compose push web
 

--- a/.template/addons/semaphore/.semaphore/promotion-staging.yml.tt
+++ b/.template/addons/semaphore/.semaphore/promotion-staging.yml.tt
@@ -24,6 +24,7 @@ blocks:
       jobs:
         - name: Build
           commands:
+            - bin/docker-prepare
             - docker-compose build
             - docker-compose push web
 

--- a/.template/addons/semaphore/.semaphore/semaphore.yml.tt
+++ b/.template/addons/semaphore/.semaphore/semaphore.yml.tt
@@ -32,6 +32,7 @@ blocks:
                 then (echo "Pulling built image for the branch"; docker-compose pull test || true);
                 else (echo "Skipping docker pull");
               fi || true
+            - bin/docker-prepare
             - docker-compose build
             - docker-compose push test
 

--- a/.template/spec/base/bin/template_spec.rb
+++ b/.template/spec/base/bin/template_spec.rb
@@ -13,4 +13,9 @@ describe '/bin template' do
     expect(file('bin/test.sh')).to exist
     expect(file('bin/test.sh')).to be_executable
   end
+
+  it 'creates the docker prepare script' do
+    expect(file('bin/docker-prepare')).to exist
+    expect(file('bin/docker-prepare')).to be_executable
+  end
 end

--- a/bin/docker-prepare
+++ b/bin/docker-prepare
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+require 'fileutils'
+
+# Copy the project dependencies to build the docker image
+DOCKER_TMP_FOLDER = 'tmp/docker'
+ENGINES_DIRECTORY = 'engines'
+
+FileUtils.rm_rf DOCKER_TMP_FOLDER
+FileUtils.mkdir DOCKER_TMP_FOLDER
+FileUtils.cp 'Gemfile', DOCKER_TMP_FOLDER
+FileUtils.cp 'Gemfile.lock', DOCKER_TMP_FOLDER
+
+exit unless File.directory?(ENGINES_DIRECTORY)
+
+engines = Dir.children(ENGINES_DIRECTORY)
+
+engines.each do |engine|
+  engine_directory = "#{DOCKER_TMP_FOLDER}/engines/#{engine}"
+
+  FileUtils.mkdir_p engine_directory
+
+  FileUtils.cp_r "engines/#{engine}/lib/", engine_directory
+  FileUtils.cp "engines/#{engine}/Gemfile", engine_directory
+  FileUtils.cp "engines/#{engine}/#{engine}.gemspec", engine_directory
+end

--- a/bin/template.rb
+++ b/bin/template.rb
@@ -1,3 +1,4 @@
 copy_file 'bin/envsetup.sh', mode: :preserve
 copy_file 'bin/start.sh', mode: :preserve
 copy_file 'bin/test.sh', mode: :preserve
+copy_file 'bin/docker-prepare', mode: :preserve

--- a/makefile
+++ b/makefile
@@ -3,6 +3,7 @@ create:
 
 build:
 	cd $(APP_NAME) && \
+	bin/docker-prepare && \
 	docker-compose -f docker-compose.test.yml build
 
 run:


### PR DESCRIPTION
## What happened

✅ Add the script to copy all app + engines dependencies for building docker image
 
## Insight

There is an issue that Heroku has the limitation for deploying the container that the image should have less than 40 layers.

 This could happen on any app, especially the one with lots of engines, because each engine would need at least 2 layers in order to bundle.

```
COPY engines/mia_website/lib/ ./engines/mia_website/lib/
COPY engines/mia_website/Gemfile engines/mia_website/mia_website.gemspec ./engines/mia_website/
```

To fix we add a script to prepare all the gemfiles on the app itself and also on all the engines before building the image. And during the build process, we just copy the directory into the image. So we could reduce a lot of layers for the app with many engines.

## Proof Of Work

Test should pass 💚 
 