### PR TITLE
Add precompiling assets script to fix docker build

### DIFF
--- a/.template/addons/docker/Dockerfile.tt
+++ b/.template/addons/docker/Dockerfile.tt
@@ -7,10 +7,6 @@ ARG SECRET_KEY_BASE=secret_key_base
 <%- if WEB_VARIANT -%>
 ARG NODE_ENV=development
 ARG ASSET_HOST=http://localhost
-# Set environment varaibles required in the initializers in order to precompile the assets.
-# Because it initializes the app, so all variables need to exist in the build stage.
-ARG MAILER_DEFAULT_HOST=http://localhost
-ARG MAILER_DEFAULT_PORT=3000
 <%- end -%>
 
 # Define all the envs here
@@ -104,8 +100,7 @@ RUN rm -rf tmp/docker
 
 <%- if WEB_VARIANT -%>
 # Compile assets
-RUN bundle exec rails i18n:js:export && \
-    bundle exec rails assets:precompile
+RUN bin/docker-assets-precompile
 
 <%- end -%>
 EXPOSE $PORT

--- a/.template/addons/docker/Dockerfile.tt
+++ b/.template/addons/docker/Dockerfile.tt
@@ -3,7 +3,6 @@ FROM ruby:<%= RUBY_VERSION %>-slim
 ARG BUILD_ENV=development
 ARG RUBY_ENV=development
 ARG APP_HOME=/<%= APP_NAME %>
-ARG SECRET_KEY_BASE=secret_key_base
 <%- if WEB_VARIANT -%>
 ARG NODE_ENV=development
 ARG ASSET_HOST=http://localhost

--- a/bin/docker-assets-precompile
+++ b/bin/docker-assets-precompile
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+
+# For building production docker image
+#
+# It sets the envs inside the docker image for precompiling the assets
+# Because to precompile the assets, Rails initializes the app.
+# And it requires the envs as we always use `ENV.fetch` to setup the variables
+#
+# Related issue: https://github.com/rails/rails/issues/32947
+
+require 'yaml'
+
+rails_env = ENV.fetch('RAILS_ENV', 'production')
+env_config = YAML.load_file('config/application.yml')[rails_env]
+
+if rails_env == 'production'
+  env_config.keys.each { |name| ENV[name] = 'dummy_value' }
+else
+  env_config.each { |name, value| ENV[name] = value }
+end
+
+exit system('bin/rails i18n:js:export && bin/rails assets:precompile')

--- a/bin/docker-assets-precompile
+++ b/bin/docker-assets-precompile
@@ -10,13 +10,7 @@
 
 require 'yaml'
 
-rails_env = ENV.fetch('RAILS_ENV', 'production')
-env_config = YAML.load_file('config/application.yml')[rails_env]
-
-if rails_env == 'production'
-  env_config.keys.each { |name| ENV[name] = 'dummy_value' }
-else
-  env_config.each { |name, value| ENV[name] = value }
-end
+env_keys = YAML.load_file('config/application.yml')['docker_build'].keys
+env_keys.each { |name| ENV[name] = 'dummy_value' }
 
 exit system('bin/rails i18n:js:export && bin/rails assets:precompile')

--- a/bin/docker-assets-precompile
+++ b/bin/docker-assets-precompile
@@ -10,7 +10,11 @@
 
 require 'yaml'
 
-env_keys = YAML.load_file('config/application.yml')['docker_build'].keys
-env_keys.each { |name| ENV[name] = 'dummy_value' }
+rails_env = ENV.fetch('RAILS_ENV', 'production')
+
+if rails_env == 'production'
+  env_keys = YAML.load_file('config/application.yml')['docker_build'].keys
+  env_keys.each { |name| ENV[name] = 'dummy_value' }
+end
 
 exit system('bin/rails i18n:js:export && bin/rails assets:precompile')

--- a/bin/template.rb
+++ b/bin/template.rb
@@ -2,3 +2,4 @@ copy_file 'bin/envsetup.sh', mode: :preserve
 copy_file 'bin/start.sh', mode: :preserve
 copy_file 'bin/test.sh', mode: :preserve
 copy_file 'bin/docker-prepare', mode: :preserve
+copy_file 'bin/docker-assets-precompile', mode: :preserve

--- a/config/application.yml.tt
+++ b/config/application.yml.tt
@@ -13,3 +13,11 @@ development:
 test:
   <<: *default
   TEST_RETRY: "0"
+
+# Set environment variables required in the initializers in order to precompile the assets.
+# Because it initializes the app, so all variables need to exist in the build stage.
+production:
+  <<: *default
+  MAILER_DEFAULT_HOST:
+  MAILER_DEFAULT_PORT:
+  SECRET_KEY_BASE:

--- a/config/application.yml.tt
+++ b/config/application.yml.tt
@@ -15,9 +15,7 @@ test:
   TEST_RETRY: "0"
 
 # Set environment variables required in the initializers in order to precompile the assets.
-# Because it initializes the app, so all variables need to exist in the build stage.
-production:
+# Because it initializes the app, so all variables need to exist in the Docker build stage (used in bin/docker-assets-precompile).
+docker_build:
   <<: *default
-  MAILER_DEFAULT_HOST:
-  MAILER_DEFAULT_PORT:
   SECRET_KEY_BASE:


### PR DESCRIPTION
## What happened

✅ Add precompile assets script
 
## Insight

In order to precompile the assets inside the docker image, we need to have all variables set to make the app successfully initializes. This is because we always use ENV.fetch to get the environment variables to fast-failing when the env is not set properly. 

To fix, we add the docker precompile assets script. Which will take all variables needed and set the dummy values. So all variables is available for the app to initialize.

## Proof Of Work

- Spec should passed 🍏
- We can run the docker-compose build successfully