### PR TITLE
Replace link to shared ESLint with the new NPMJS organization

### DIFF
--- a/.template/spec/variants/web/package_json_spec.rb
+++ b/.template/spec/variants/web/package_json_spec.rb
@@ -16,7 +16,7 @@ describe 'Web variant - package.json' do
 
   describe 'Development Dependencies' do
     it 'adds Nimble eslint config dependency' do
-      expect(subject['devDependencies']).to include('@nimbl3/eslint-config-nimbl3')
+      expect(subject['devDependencies']).to include('@nimblehq/eslint-config-nimble')
     end
   end
 end

--- a/.template/variants/web/.eslintrc
+++ b/.template/variants/web/.eslintrc
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "@nimbl3/eslint-config-nimbl3"
+    "@nimblehq/eslint-config-nimble"
   ],
   "globals": {
     "I18n": true

--- a/.template/variants/web/package.json.rb
+++ b/.template/variants/web/package.json.rb
@@ -16,7 +16,7 @@ end
 insert_into_file 'package.json', before: %r{"version":.+\n} do
   <<~EOT
       "devDependencies": {
-        "@nimbl3/eslint-config-nimbl3": "2.1.1"
+        "@nimblehq/eslint-config-nimble": "2.1.1"
       },
   EOT
 end


### PR DESCRIPTION
## What happened

Update the link to ESLint shared library from `nimbl3` to `nimblehq` NPMJS organization.
 
## Insight

Linked PR on the ESLint repository: https://github.com/nimblehq/eslint-config-nimble/pull/6 

## Proof Of Work

`N/A` 