### PR TITLE
[Chore] Fix bundler#v2.1 deprecated messages for --deployment, --path, --without

### DIFF
--- a/.template/addons/docker/Dockerfile.tt
+++ b/.template/addons/docker/Dockerfile.tt
@@ -83,15 +83,13 @@ COPY tmp/docker ./
 
 # Install Ruby gems
 RUN gem install bundler && \
+    bundle config set jobs $BUNDLE_JOBS && \
+    bundle config set path $BUNDLE_PATH && \
     if [ "$BUILD_ENV" = "production" ]; then \
-      bundle install --jobs $BUNDLE_JOBS \
-                     --path $BUNDLE_PATH \
-                     --without development test \
-                     --deployment ; \
-    else \
-      bundle install --jobs $BUNDLE_JOBS \
-                     --path $BUNDLE_PATH ; \
-    fi
+      bundle config set deployment yes && \
+      bundle config set without 'development test' ; \
+    fi && \
+    bundle install
 
 <%- if WEB_VARIANT -%>
 # Install JS dependencies


### PR DESCRIPTION
## What happened
Describe the big picture of your changes here to communicate to the team why we should accept this pull request. 
- Change the way to config bundler as `bundler 2.1` has changed their configuration command
 
## Insight
Describe in detail how to test the changes. Referenced documentations are welcome as well.
- https://github.com/rubygems/bundler/releases/tag/v2.1.4

## Proof Of Work
Show us the implementation: screenshots, gifs, etc.
 