### PR TITLE
Upgrade to Ruby 2.7.1 and Rails 6.0.3.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,8 @@ AllCops:
     - 'Guardfile'
     - 'node_modules/**/*'
     - 'config/**/*'
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
+  NewCops: enable
 
 Style/Documentation:
   Enabled: false

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -13,7 +13,7 @@ global_job_config:
   prologue:
     commands:
       - checkout
-      - sem-version ruby 2.6.5
+      - sem-version ruby 2.7.1
       - sem-version node 12.16.1
       - export BRANCH_TAG=${SEMAPHORE_GIT_BRANCH/\//-}
       - export CACHE_NAME=$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_PIPELINE_ID
@@ -24,7 +24,7 @@ global_job_config:
     - name: COMPOSE_FILE
       value: docker-compose.test.yml
     - name: RAILS_VERSION
-      value: 6.0.1
+      value: 6.0.3.2
   secrets:
     - name: rails-templates
 

--- a/.template/Gemfile.lock
+++ b/.template/Gemfile.lock
@@ -1,23 +1,23 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.3)
+    diff-lcs (1.4.4)
     docker-api (1.34.2)
       excon (>= 0.47.0)
       multi_json
-    excon (0.72.0)
-    multi_json (1.14.1)
-    net-scp (2.0.0)
-      net-ssh (>= 2.6.5, < 6.0.0)
-    net-ssh (5.2.0)
+    excon (0.75.0)
+    multi_json (1.15.0)
+    net-scp (3.0.0)
+      net-ssh (>= 2.6.5, < 7.0.0)
+    net-ssh (6.1.0)
     net-telnet (0.1.1)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
       rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.1)
-      rspec-support (~> 3.9.1)
-    rspec-expectations (3.9.0)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-its (1.3.0)
@@ -26,7 +26,7 @@ GEM
     rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
-    rspec-support (3.9.2)
+    rspec-support (3.9.3)
     rspec-wait (0.0.9)
       rspec (>= 3, < 4)
     serverspec (2.41.5)
@@ -35,7 +35,7 @@ GEM
       rspec-its
       specinfra (~> 2.72)
     sfl (2.3)
-    specinfra (2.82.9)
+    specinfra (2.82.18)
       net-scp
       net-ssh (>= 2.7)
       net-telnet (= 0.1.1)
@@ -51,4 +51,4 @@ DEPENDENCIES
   serverspec
 
 BUNDLED WITH
-   1.17.2
+   2.1.4

--- a/Gemfile.tt
+++ b/Gemfile.tt
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 ruby '<%= RUBY_VERSION %>'
 
 # Backend
-gem 'rails', '6.0.1' # Latest stable
+gem 'rails', '6.0.3.2' # Latest stable
 gem 'pg' # Use Postgresql as database
 gem 'puma' # Use Puma as the app server
 gem 'mini_magick' # A ruby wrapper for ImageMagick or GraphicsMagick command line

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ with building complex applications over the years.
 
 ### Requirements
 
-- Install ruby and set your local ruby version to `2.6.5`
-- Install rails > `6.0.0`, recommended version `6.0.1`
+- Install ruby and set your local ruby version to `2.7.1`
+- Install rails > `6.0.0`, recommended version `6.0.3.2`
 
 ### Use the template
 

--- a/template.rb
+++ b/template.rb
@@ -5,7 +5,7 @@ APP_NAME = app_name
 # Transform the app name from slug to human-readable name e.g. nimble-web -> Nimble
 APP_NAME_HUMANIZED = app_name.split(/[-_]/).map(&:capitalize).join(' ').gsub(/ Web$/, '')
 DOCKER_IMAGE = "nimblehq/#{APP_NAME}".freeze
-RUBY_VERSION = '2.6.5'.freeze
+RUBY_VERSION = '2.7.1'.freeze
 POSTGRES_VERSION = '12.1'.freeze
 REDIS_VERSION = '5.0.7'.freeze
 # Variants


### PR DESCRIPTION
## What happened
- Upgrade Ruby to the latest stable version (2.7.1)
- Upgrade Rails to the latest stable version (6.0.3.2)
- Fix `.rubocop.yml`
- Upgrade bundler version

## Insight
- Modify `.rubocop.yml` with new `TargetRubyVersion` and enable all `NewCops` 
- Run `bundler update` in `.template` folder

## Proof Of Work
![localhost_3000_(Laptop with MDPI screen)](https://user-images.githubusercontent.com/7344405/87691099-6c1b7180-c7b4-11ea-9bcc-50f60b454650.png)
