### PR TITLE
Prepare webpack assets only if there is at least one system test

### DIFF
--- a/.template/variants/web/spec/support/webpack.rb
+++ b/.template/variants/web/spec/support/webpack.rb
@@ -1,5 +1,5 @@
 RSpec.configure do |config|
-  config.before(:suite) do
+  config.when_first_matching_example_defined(type: :system) do
     if ENV['TEST_SKIP_ASSET'].blank?
       puts 'Prepare webpack assets for test environment'
 


### PR DESCRIPTION
## What happened
Prepare webpack assets only if there is at least one system test is executed

## Insight
Just change to use `when_first_matching_example_defined` config

## Proof Of Work
- Run normal tests (not type: :system) faster without webpack compilation
- The webpack compilation should be run once before running system tests
 