### PR TITLE
Fixing rubocop issue in disable_animation.rb

### DIFF
--- a/.template/variants/web/spec/support/disable_animation.rb
+++ b/.template/variants/web/spec/support/disable_animation.rb
@@ -52,7 +52,7 @@ module Rack
   }
 </style>
       EOF
-      fragment.gsub(%r{</head>}, disable_animations + '</head>')
+      fragment.gsub(%r{</head>}, "#{disable_animations}</head>")
     end
     # rubocop:enable Metrics/MethodLength
     # rubocop:enable Naming/HeredocDelimiterNaming


### PR DESCRIPTION
## What happened
Fixing rubocop issue in disable_animation.rb

 
## Insight
Just following https://github.com/nimblehq/rails-templates/pull/195/files#diff-ff1a9ebbc2b786f43d96a4aab0a88c0eR55
 

## Proof Of Work
Before

![image](https://user-images.githubusercontent.com/11751745/90388532-1e936c80-e0b2-11ea-9fbc-52e9b166957b.png)


After

The test should passed ✅ ✅ ✅ 
 