### PR TITLE
Moving rspec-rails to development and test group

### DIFF
--- a/Gemfile.tt
+++ b/Gemfile.tt
@@ -40,6 +40,7 @@ group :development, :test do
   gem 'listen', '3.1.5' # Listens to file modifications
   gem 'letter_opener' # Preview mail in the browser instead of sending.
   gem 'brakeman', require: false # A static analysis security vulnerability scanner for Ruby on Rails applications
+  gem 'rspec-rails', '~> 4.0.1' # Rails testing engine
   gem 'rubocop', require: false
   gem 'rubocop-rails', require: false
 
@@ -52,7 +53,6 @@ group :development, :test do
 end
 
 group :test do
-  gem 'rspec-rails', '>=4.0.0.beta2' # Rails testing engine
   gem 'rspec-retry' # Retry randomly failing rspec example.
   gem 'database_cleaner' # Use Database Cleaner
   gem 'shoulda-matchers' # Tests common Rails functionalities


### PR DESCRIPTION
## What happened
Resolve #192

 
## Insight
Just moving the `rspec-rails` to development group so the generate will work on development

https://github.com/rspec/rspec-rails#installation

<img width="788" alt="Pasted_Image_8_18_20__11_36" src="https://user-images.githubusercontent.com/11751745/90470962-0b7eac00-e147-11ea-862d-0f18b2c4a965.png">


## Proof Of Work

 
<img width="572" alt="Pasted_Image_8_18_20__11_36" src="https://user-images.githubusercontent.com/11751745/90470990-1afdf500-e147-11ea-9240-0bc3cfb9086d.png">
