### PR TITLE
Adding Engine prefix name validator

### DIFF
--- a/spec/codebase/codebase_spec.rb
+++ b/spec/codebase/codebase_spec.rb
@@ -13,6 +13,15 @@ describe 'Codebase', codebase: true do
     expect(`bundle exec rake zeitwerk:check`).to include 'All is good!'
   end
 
+  it 'does not offend engine prefix name' do
+    engine_paths = Dir[File.expand_path(Rails.root.join('engines', '*'))]
+                   .select { |f| File.directory? f }
+                   .map { |path| path.split('/').last }
+    invalid_engine_paths = engine_paths.reject { |path| path.start_with?("APP_NAME_HERE") }
+
+    expect(invalid_engine_paths).to be_empty
+  end
+
   context 'respond_to blocks' do
     it 'does not contain respond_to blocks' do
       find_results = `grep -r 'respond_to do' app/`

--- a/spec/codebase/codebase_spec.rb
+++ b/spec/codebase/codebase_spec.rb
@@ -17,7 +17,7 @@ describe 'Codebase', codebase: true do
     engine_paths = Dir[File.expand_path(Rails.root.join('engines', '*'))]
                    .select { |f| File.directory? f }
                    .map { |path| path.split('/').last }
-    invalid_engine_paths = engine_paths.reject { |path| path.start_with?("APP_NAME_HERE") }
+    invalid_engine_paths = engine_paths.reject { |path| path.start_with?("APP_NAME_HERE_") }
 
     expect(invalid_engine_paths).to be_empty
   end

--- a/spec/codebase/codebase_spec.rb
+++ b/spec/codebase/codebase_spec.rb
@@ -17,7 +17,7 @@ describe 'Codebase', codebase: true do
     engine_paths = Dir[File.expand_path(Rails.root.join('engines', '*'))]
                    .select { |f| File.directory? f }
                    .map { |path| path.split('/').last }
-    invalid_engine_paths = engine_paths.reject { |path| path.start_with?("APP_NAME_HERE_") }
+    invalid_engine_paths = engine_paths.reject { |path| path.start_with?('APP_NAME_HERE_') }
 
     expect(invalid_engine_paths).to be_empty
   end

--- a/spec/template.rb
+++ b/spec/template.rb
@@ -10,8 +10,8 @@ if File.exist?('spec/codebase/codebase_spec.rb')
     app_name
   end
 else
-  @template_errors.add <<~EOT
-    Cannot insert the app name into `spec/codebase/codebase_spec.rb`
+  @template_errors.add <<~ERROR
+    Cannot insert the app_name into `spec/codebase/codebase_spec.rb`
     Content: #{app_name}
-  EOT
+  ERROR
 end

--- a/spec/template.rb
+++ b/spec/template.rb
@@ -3,3 +3,15 @@ generate 'rspec:install'
 directory 'spec', force: true
 
 copy_file '.rspec', force: true
+
+# Engine prefix name validator
+if File.exist?('spec/codebase/codebase_spec.rb')
+  gsub_file 'spec/codebase/codebase_spec.rb', /APP_NAME_HERE/ do
+    app_name
+  end
+else
+  @template_errors.add <<~EOT
+    Cannot insert the app name into `spec/codebase/codebase_spec.rb`
+    Content: #{app_name}
+  EOT
+end


### PR DESCRIPTION
## What happened
Resolve #203 

 
## Insight
Just adding a piece code that validates the engine prefix names (that worked in The1 project)
 

## Proof Of Work
<img width="730" alt="Pasted_Image_8_18_20__11_49" src="https://user-images.githubusercontent.com/11751745/90471593-df642a80-e148-11ea-9e70-a6c37b622f5e.png">


 