### PR TITLE
Remove the spec/template.rb in the new app

### DIFF
--- a/spec/template.rb
+++ b/spec/template.rb
@@ -1,6 +1,5 @@
 generate 'rspec:install'
 
-directory 'spec', force: true
-FileUtils.rm('spec/template.rb')
+directory 'spec', exclude_pattern: 'template.rb', force: true
 
 copy_file '.rspec', force: true

--- a/spec/template.rb
+++ b/spec/template.rb
@@ -1,5 +1,6 @@
 generate 'rspec:install'
 
 directory 'spec', force: true
+FileUtils.rm('spec/template.rb')
 
 copy_file '.rspec', force: true


### PR DESCRIPTION
## What happened
Resolve #211

 
## Insight
Just remove the file because the `directory 'spec', force: true` copied the whole rspec folder
 

## Proof Of Work
![image](https://user-images.githubusercontent.com/11751745/90480966-38d55500-e15b-11ea-8cec-5eeff308b410.png)

 