### PR TITLE
Remove redundant IrresponsibleModule smell in Reek config

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -12,8 +12,6 @@ detectors:
 ### Directory specific configuration
 directories:
   "app/controllers":
-    IrresponsibleModule:
-      enabled: false
     NestedIterators:
       max_allowed_nesting: 2
     UnusedPrivateMethod:
@@ -21,8 +19,6 @@ directories:
     InstanceVariableAssumption:
       enabled: false
   "app/helpers":
-    IrresponsibleModule:
-      enabled: false
     UtilityFunction:
       enabled: false
   "app/mailers":


### PR DESCRIPTION
## What happened
Just removing the redundant IrresponsibleModule smells in the Reek config file
 
## Insight
In the Reek configuration file, we already disable the IrresponsibleModule under the Detectors configuration so disable it again under directories configurations is redundant. This PR simply remove them.
```yml
detectors:
  IrresponsibleModule:
    enabled: false

directories:
  "app/controllers":
    IrresponsibleModule:
      enabled: false
    ...
  "app/helpers":
    IrresponsibleModule:
      enabled: false
    ...
```
 

## Proof Of Work
Tests still passed
 