### PR TITLE
Fix Rubocop offense when first use template

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
     - 'Guardfile'
     - 'node_modules/**/*'
     - 'config/**/*'
+    - 'tmp/**/*'
   TargetRubyVersion: 2.7
   NewCops: enable
 

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -42,7 +42,9 @@ RSpec.configure do |config|
     vcr_cassettes = vcr_options[:cassettes] || Array(vcr_options[:cassette])
     cassette_group = vcr_options[:group]
     vcr_cassettes.map! { |cassette| "#{cassette_group}/#{cassette}" } if cassette_group.present?
-    vcr_cassettes.each { |c| puts c }
-    vcr_cassettes.each { |cassette| VCR.use_cassette(cassette, cassette_options, &example) }
+    vcr_cassettes.each do |cassette|
+      puts cassette
+      VCR.use_cassette(cassette, cassette_options, &example)
+    end
   end
 end


### PR DESCRIPTION
## What happened
- When I start using this template, run test failed
- And when run `rubocop` command after `docker-prepare` things broken.
<img width="1440" alt="Screen Shot 2563-09-11 at 17 50 57" src="https://user-images.githubusercontent.com/29707647/92921040-8f356b00-f45d-11ea-8a2a-ec46c8fcadbf.png">


## Insight
- Update rubocop config to ignore tmp folder
- Combine loops in `vcr.rb` file according to rubocop error
 

## Proof Of Work
- When initialize a new app using this template, test will pass when you `run test`
- After `docker-prepare`, everything should work fine when you run `rubocop` command
<img width="1440" alt="Screen Shot 2563-09-11 at 18 17 10" src="https://user-images.githubusercontent.com/29707647/92921190-cf94e900-f45d-11ea-9117-c2b8713b9ceb.png">
 