### PR TITLE
Fix missing gems when running app with docker

### DIFF
--- a/.template/addons/docker/Dockerfile.tt
+++ b/.template/addons/docker/Dockerfile.tt
@@ -3,8 +3,6 @@ FROM ruby:<%= RUBY_VERSION %>-slim
 ARG BUILD_ENV=development
 ARG RUBY_ENV=development
 ARG APP_HOME=/<%= APP_NAME %>
-ARG BUNDLE_JOBS=4
-ARG BUNDLE_PATH="/bundle"
 ARG SECRET_KEY_BASE=secret_key_base
 <%- if WEB_VARIANT -%>
 ARG NODE_ENV=development
@@ -20,6 +18,8 @@ ENV BUILD_ENV=$BUILD_ENV \
     RACK_ENV=$RUBY_ENV \
     RAILS_ENV=$RUBY_ENV \
     PORT=80 \
+    BUNDLE_JOBS=4 \
+    BUNDLE_PATH="/bundle" \
     <%- if WEB_VARIANT -%>
     ASSET_HOST=$ASSET_HOST \
     NODE_ENV=$NODE_ENV \


### PR DESCRIPTION
## What happened
We didn't set `BUNDLE_PATH` environment variable in Dockerfile, then when starting the app, it raised the following error:
![image](https://user-images.githubusercontent.com/7344405/93553737-014a0a80-f99e-11ea-83d1-c0ed57a40ef6.png)


## Insight
Just move the `BUNDLE_PATH ` and `BUNDLE_JOBS` to ENV section

## Proof Of Work
The error shouldn't happen again
 