### PR TITLE
Fix error when applying an addon to existing project

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -124,7 +124,7 @@ require "#{template_root}/.template/lib/template/errors"
 if ENV['ADDON']
   addon_template_path = ".template/addons/#{ENV['ADDON']}/template.rb"
 
-  abort 'This addon is not supported' unless File.exist?(addon_template_path)
+  abort 'This addon is not supported' unless File.exist?(File.expand_path(addon_template_path, template_root))
 
   apply addon_template_path
 else


### PR DESCRIPTION
## What happened
Fix error when applying an addon to existing project
 
## Insight
- When applying github addon, it didn't work. The reason is `File.exist?(addon_template_path)` didn't find the file because it checked the file on the current working dir (the current project that running the script). Use `File.expand_path` with `template_root` parameter to get the file absolute path of the current file on template
 

## Proof Of Work
- Tests should be passed
- You can add the github actions workflows to existing projects by applying the github addon:
`rails app:template LOCATION=https://raw.githubusercontent.com/nimblehq/rails-templates/bug/unable-to-apply-addon/template.rb ADDON=docker`

 
![Screen_Shot_2020-09-22_at_17_20_37](https://user-images.githubusercontent.com/7344405/93871131-5ff1ea00-fcf8-11ea-94c3-e1cf64ec855a.png)
