### PR TITLE
Add rails-controller-testing to Gemfile template

### DIFF
--- a/Gemfile.tt
+++ b/Gemfile.tt
@@ -61,6 +61,7 @@ group :test do
   gem 'simplecov', require: false # code coverage analysis tool for Ruby
   gem 'vcr' # Gem for recording test suite's HTTP interactions
   gem 'timecop' # Gem for time travel
+  gem 'rails-controller-testing' # Gem that allow to use assigns as well ass assert_template
 end
 
 group :production do


### PR DESCRIPTION
## What happened
I tried to assert template in my Internal Certification. For example in this code
```ruby
describe "GET new" do 
  it "renders the new view" do 
    get :new

    expect(response).to render_template(:new)
  end
end
```
I got an error
<img width="511" alt="Screen Shot 2563-09-24 at 16 15 11" src="https://user-images.githubusercontent.com/29707647/94127283-f18d6300-fe82-11ea-803d-c436daa01c6b.png">

So `rails-controller-testing` allow us to use `assigns` and `assert_template`.


## Insight
- Add `rails-controller-testing` to Gemfile template

Note : @hoangmirs concern is if there is another alternative or not because the last release of this lib was 4 years ago.
 

## Proof Of Work
- Test case above is passed
 