### PR TITLE
Allow Rails serve static files as default

### DIFF
--- a/.template/spec/base/config/environments/production_spec.rb
+++ b/.template/spec/base/config/environments/production_spec.rb
@@ -9,7 +9,7 @@ describe 'config/environments/production.rb' do
     expect(subject).to contain(mailer_default_url_config)
   end
 
-  it 'allow Rails serve static file' do
+  it 'allows Rails serve static file' do
     expect(subject).to contain('config.public_file_server.enabled = true')
   end
   

--- a/.template/spec/base/config/environments/production_spec.rb
+++ b/.template/spec/base/config/environments/production_spec.rb
@@ -9,6 +9,10 @@ describe 'config/environments/production.rb' do
     expect(subject).to contain(mailer_default_url_config)
   end
 
+  it 'allow Rails serve static file' do
+    expect(subject).to contain('config.public_file_server.enabled = true')
+  end
+  
   private
 
   def mailer_default_url_config

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,6 @@
+# Allow Rails serve static file by default, this can be disable on Nginx addon
+gsub_file('config/environments/production.rb', "ENV['RAILS_SERVE_STATIC_FILES'].present?", 'true')
+
 insert_into_file 'config/environments/production.rb', after: %r{config.action_mailer.perform_caching.+\n} do
   <<-EOT
 


### PR DESCRIPTION
## What happened
Solve https://github.com/nimblehq/rails-templates/issues/234

 
## Insight
Allow Rails server static by default as by default we don't have the Web server by default (like Nginx, Apache,..)

This configuration could be disabled on the [Nginx addon PR](https://github.com/nimblehq/rails-templates/pull/232)

## Proof Of Work
The test should be passed
 