### PR TITLE
Only run asset precompile on system test

### DIFF
--- a/.template/variants/web/spec/support/assets.rb
+++ b/.template/variants/web/spec/support/assets.rb
@@ -1,5 +1,5 @@
 RSpec.configure do |config|
-  config.before(:suite) do
+  config.when_first_matching_example_defined(type: :system) do
     # On CI we use Docker and the assets are precompiled (in the Dockerfile) already
     # On local, usually we run the test on the host machine so have to precompile the assets before running the test
     `bundle exec rails assets:precompile RAILS_ENV=test NODE_ENV=test` unless ENV['CI']


### PR DESCRIPTION
## What happened
Prepare webpack assets only if there is at least one system test is executed, solve https://github.com/nimblehq/rails-templates/issues/205

## Insight
Just change to use when_first_matching_example_defined config
 
## Proof Of Work
Run normal tests (not type: :system) faster without webpack compilation
The webpack compilation should be run once before running system tests