### PR TITLE
Adding rubocop-rspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
-require: rubocop-rails
-require: rubocop-rspec
+require: 
+  - rubocop-rails
+  - rubocop-rspec
 
 AllCops:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 require: rubocop-rails
+require: rubocop-rspec
 
 AllCops:
   Exclude:
@@ -33,3 +34,9 @@ Style/FormatStringToken:
 
 Rails/FilePath:
   EnforcedStyle: arguments
+
+RSpec/HookArgument:
+  EnforcedStyle: each
+
+RSpec/ContextWording:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,4 +40,6 @@ RSpec/HookArgument:
   EnforcedStyle: each
 
 RSpec/ContextWording:
-  Enabled: false
+  Prefixes:
+    - when
+    - given

--- a/Gemfile.tt
+++ b/Gemfile.tt
@@ -41,8 +41,9 @@ group :development, :test do
   gem 'letter_opener' # Preview mail in the browser instead of sending.
   gem 'brakeman', require: false # A static analysis security vulnerability scanner for Ruby on Rails applications
   gem 'rspec-rails', '~> 4.0.1' # Rails testing engine
-  gem 'rubocop', require: false
-  gem 'rubocop-rails', require: false
+  gem 'rubocop', require: false # A Ruby static code analyzer and formatter, based on the community Ruby style guide.
+  gem 'rubocop-rails', require: false # A RuboCop extension focused on enforcing Rails best practices and coding conventions.
+  gem 'rubocop-rspec', require: false # Code style checking for RSpec files
 
   gem 'danger' # Automated code review.
   gem 'danger-rubocop' # A Danger plugin for Rubocop.

--- a/spec/codebase/codebase_spec.rb
+++ b/spec/codebase/codebase_spec.rb
@@ -22,15 +22,13 @@ describe 'Codebase', codebase: true do
     expect(invalid_engine_paths).to be_empty
   end
 
-  context 'respond_to blocks' do
-    it 'does not contain respond_to blocks' do
-      find_results = `grep -r 'respond_to do' app/`
-      expect(find_results).to be_empty
-    end
+  it 'does not contain respond_to blocks' do
+    find_results = `grep -r 'respond_to do' app/`
+    expect(find_results).to be_empty
+  end
 
-    it 'does not contain format blocks' do
-      find_results = `grep -r 'format.json' app/`
-      expect(find_results).to be_empty
-    end
+  it 'does not contain format blocks' do
+    find_results = `grep -r 'format.json' app/`
+    expect(find_results).to be_empty
   end
 end


### PR DESCRIPTION
## What happened
Solved https://github.com/nimblehq/rails-templates/issues/124

 
## Insight
1/ Adding [rubocop-rspec](https://github.com/rubocop-hq/rubocop-rspec)

2/ Modify some Rubocop Rspec rule

- [RSpec/HookArgument](https://www.rubydoc.info/gems/rubocop-rspec/1.7.0/RuboCop/Cop/RSpec/HookArgument): Prefer to keep the `each` argument in the Rspec hooks., eg: `before(:each)` or `after(:each)`

- [RSpec/ContextWording](https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextWording): We are using `given ...` term in most of our test


## Proof Of Work
The rubocop-rspec is load 

![Screen Shot 2020-10-08 at 10 31 35](https://user-images.githubusercontent.com/11751745/95412768-eabb2180-0953-11eb-9c07-eb42b3b2bccc.png)