### PR TITLE
Add github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -1,0 +1,20 @@
+---
+name: "Bug Report"
+about: "You found something that is not working. Report it so that it can be fixed. 👷‍"
+title: "Fix: "
+labels: "type : bug"
+---
+
+## Issue
+
+Describe the issue you are facing. Show us the implementation: screenshots, gif, etc.
+ 
+## Expected
+
+Describe what should be the correct behaviour.
+ 
+## Steps to reproduce
+
+1. 
+2. 
+3. 

--- a/.github/ISSUE_TEMPLATE/feature_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_template.md
@@ -1,0 +1,14 @@
+---
+name: "Feature"
+about: "Open a feature issue to add new functionalities."
+title: "Add "
+labels: "type : feature"
+---
+
+## Why
+
+Describe the big picture of the feature and why it's needed. 
+ 
+## Who Benefits?
+
+Describe who will be the beneficiaries e.g. everyone, specific chapters, clients...


### PR DESCRIPTION
## What happened

Added the GitHub issue template.
 
## Insight

Used the same template as our git-template - https://github.com/nimblehq/git-template/tree/master/.github/ISSUE_TEMPLATE 

## Proof Of Work
- New Issue

![image](https://user-images.githubusercontent.com/14927672/96567933-31603280-12e9-11eb-8e48-d41b9fed0a95.png)

- Bug Report

![image](https://user-images.githubusercontent.com/14927672/96568034-4dfc6a80-12e9-11eb-84f3-8ed13cb4b600.png)

- Feature

![image](https://user-images.githubusercontent.com/14927672/96568098-610f3a80-12e9-11eb-9993-2f8418d48ffc.png)



