### PR TITLE
Add danger plugin danger-undercover

### DIFF
--- a/.semaphore.yml
+++ b/.semaphore.yml
@@ -17,10 +17,11 @@ project_settings:
       - docker push $DOCKER_IMAGE:$BRANCH_TAG
 
     unit_tests:
-      - if ([ $BRANCH_NAME != 'master' ] && [ $BRANCH_NAME != 'development' ]); then (echo "Running Danger"; docker-compose -f docker-compose.test.yml run test bundle exec danger); else (echo "Escaping Danger"); fi || true
       - docker-compose -f docker-compose.test.yml run test yarn lint
       - docker-compose -f docker-compose.test.yml run test yarn test
       - docker-compose -f docker-compose.test.yml run test rspec --exclude-pattern "spec/systems/**/*_spec.rb" --profile
+      - if ([ $BRANCH_NAME != 'master' ] && [ $BRANCH_NAME != 'development' ]); then (echo "Running Undercover"; docker-compose -f docker-compose.test.yml run test bundle exec undercover-report -c origin/development); else (echo "Escaping Undercover"); fi || true
+      - if ([ $BRANCH_NAME != 'master' ] && [ $BRANCH_NAME != 'development' ]); then (echo "Running Danger"; docker-compose -f docker-compose.test.yml run test bundle exec danger); else (echo "Escaping Danger"); fi || true
 
     system_tests:
       - docker-compose -f docker-compose.test.yml run test rspec spec/systems/ --profile

--- a/Dangerfile
+++ b/Dangerfile
@@ -17,3 +17,6 @@ suggester.suggest
 
 # Report your Ruby app test suite code coverage in Danger.
 simplecov.report 'coverage/coverage.json'
+
+# Report missing test coverage of new changes in Danger
+undercover.report

--- a/Gemfile.tt
+++ b/Gemfile.tt
@@ -44,6 +44,7 @@ group :development, :test do
   gem 'rubocop-rspec', require: false # Code style checking for RSpec files
   gem 'rubocop-performance', require: false # An extension of RuboCop focused on code performance checks.
 
+  gem 'undercover' # Report missing test coverage in new changes
   gem 'danger' # Automated code review.
   gem 'danger-rubocop' # A Danger plugin for Rubocop.
   gem 'danger-rails_best_practices' # Analyze code regarding best practices.
@@ -51,6 +52,7 @@ group :development, :test do
   gem 'danger-brakeman_scanner' # Security static analysis scanner in danger.
   gem 'danger-suggester' # Suggest code changes based on configured code formatter.
   gem 'danger-simplecov_json' # Report your Ruby app test suite code coverage in Danger.
+  gem 'danger-undercover' # Report missing test coverage of new changes in Danger
 end
 
 group :test do
@@ -61,6 +63,7 @@ group :test do
   gem 'webmock' # Library for stubbing and setting expectations on HTTP requests in Ruby
   gem 'simplecov', require: false # code coverage analysis tool for Ruby
   gem 'simplecov-json', require: false # JSON formatter for simplecov
+  gem 'simplecov-lcov', require: false # LCOV report for undercover
   gem 'vcr' # Gem for recording test suite's HTTP interactions
   gem 'timecop' # Gem for time travel
   gem 'rails-controller-testing' # Gem that allow to use assigns as well ass assert_template

--- a/spec/support/simplecov.rb
+++ b/spec/support/simplecov.rb
@@ -1,7 +1,8 @@
 require 'simplecov'
 require 'simplecov-json'
+require 'simplecov-lcov'
 
-formatters = [SimpleCov::Formatter::HTMLFormatter, SimpleCov::Formatter::JSONFormatter]
+formatters = [SimpleCov::Formatter::HTMLFormatter, SimpleCov::Formatter::JSONFormatter, SimpleCov::Formatter::LcovFormatter]
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(formatters)
 
 if ENV['CIRCLE_ARTIFACTS']


### PR DESCRIPTION
## What happened
Added [danger-undercover](https://github.com/nimblehq/danger-undercover) plugin to show missing test coverage in new changes in PRs with [undercover](https://github.com/grodowski/undercover)
 
## Insight
As mentioned in this [comment](https://github.com/nimblehq/rails-templates/issues/221#issuecomment-690124978) in the PR: https://github.com/nimblehq/rails-templates/issues/221 we want to show a report about missing test coverages in new changes with `undercover` in PRs using `Danger`.

## Proof Of Work

**Used in our internal project -**

- No Changes

![image](https://user-images.githubusercontent.com/14927672/96212395-9ab60d80-0f98-11eb-950a-494cca591e98.png)

- Changes in new commits

![image](https://user-images.githubusercontent.com/14927672/96212414-a99cc000-0f98-11eb-9b07-c74b9fc2de1c.png)
 