### PR TITLE
Update Rails to the latest stable version 6.1.0

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,7 +24,7 @@ global_job_config:
     - name: COMPOSE_FILE
       value: docker-compose.test.yml
     - name: RAILS_VERSION
-      value: 6.0.3.2
+      value: 6.1.0
   secrets:
     - name: rails-templates
 

--- a/Gemfile.tt
+++ b/Gemfile.tt
@@ -2,12 +2,12 @@ source 'https://rubygems.org'
 ruby '<%= RUBY_VERSION %>'
 
 # Backend
-gem 'rails', '6.0.3.2' # Latest stable
+gem 'rails', '6.1.0' # Latest stable
 gem 'pg' # Use Postgresql as database
 gem 'puma' # Use Puma as the app server
 gem 'mini_magick' # A ruby wrapper for ImageMagick or GraphicsMagick command line
 gem 'pagy' # A pagination gem that is very light and fast
-gem 'paranoia', '2.4.2' # Paranoia is a re-implementation of acts_as_paranoid for Rails 3 and Rails 4. Soft-deletion of records
+gem 'paranoia' # Paranoia is a re-implementation of acts_as_paranoid for Rails 3 and Rails 4. Soft-deletion of records
 gem 'ffaker' # A library for generating fake data such as names, addresses, and phone numbers.
 gem 'fabrication' # Fabrication generates objects in Ruby. Fabricators are schematics for your objects, and can be created as needed anywhere in your app or specs.
 gem 'sidekiq' # background processing for Ruby

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ with building complex applications over the years.
 ### Requirements
 
 - Install ruby and set your local ruby version to `2.7.1`
-- Install rails > `6.0.0`, recommended version `6.0.3.2`
+- Install rails > `6.0.0`, recommended version `6.1.0`
 
 ### Use the template
 


### PR DESCRIPTION
## What happened
Upgrade Rails to v6.1 - the latest stable version

 
## Insight
Remove the version constraint for the [paranoia](https://github.com/rubysherpas/paranoia) gem: we had to explicitly set it to v2.4.2 when upgrading Rails to v6.0.1 in #116 because the previous versions don't work with Rails 6.
But for now, the latest version ([v2.4.3](https://github.com/rubysherpas/paranoia/releases/tag/2.4.3)) supports Rails 6.1.0 already so that constraint isn't necessary anymore:
<img width="446" alt="Screen Shot 2020-12-22 at 16 34 44" src="https://user-images.githubusercontent.com/1896814/102873356-9bc15a80-4473-11eb-851f-15f2d25c56e4.png">

## Proof Of Work
<img width="578" alt="Screen Shot 2020-12-22 at 16 28 04" src="https://user-images.githubusercontent.com/1896814/102872718-afb88c80-4472-11eb-8d6c-d7fd67ddb3be.png">

 