### PR TITLE
Fix: backtrace_silencers modification does not work on the latest rails version

### DIFF
--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -1,5 +1,5 @@
-gsub_file 'config/initializers/backtrace_silencers.rb', 
-  "# Rails.backtrace_cleaner.remove_silencers!",
+gsub_file 'config/initializers/backtrace_silencers.rb',
+  "Rails.backtrace_cleaner.remove_silencers! if ENV[\"BACKTRACE\"]",
   <<-EOT
 Rails.backtrace_cleaner.remove_silencers!
 
@@ -10,5 +10,5 @@ Rails.backtrace_cleaner.remove_silencers!
 Rails.backtrace_cleaner.add_silencer do |line|
   !(Rails::BacktraceCleaner::APP_DIRS_PATTERN.match?(line) || /^engines/.match?(line))
 end
-  
+
   EOT


### PR DESCRIPTION
## What happened
Solve https://github.com/nimblehq/rails-templates/issues/264
 
## Insight
Just change the string to be replaced

## Proof Of Work
Create a new project from the template and `config/initializers/backtrace_silencers.rb` has been changed
![backtrace_silencers_rb_—_test_new](https://user-images.githubusercontent.com/7344405/104269847-cda16c00-54c9-11eb-8f01-aa025a6fac61.png)
