### PR TITLE
Correct the Turbolink removal for application.js

### DIFF
--- a/.template/variants/web/template.rb
+++ b/.template/variants/web/template.rb
@@ -42,11 +42,13 @@ def remove_turbolinks
   end
 
   if File.exist?('app/javascript/packs/application.js')
-    gsub_file('app/javascript/packs/application.js', %r{^require\(\"turbolinks\"\).start\(\)\n}, '')
+    gsub_file('app/javascript/packs/application.js', %r{import Turbolinks from "turbolinks"\n}, '')
+    gsub_file('app/javascript/packs/application.js', %r{Turbolinks.start\(\)\n}, '')
   else
     @template_errors.add <<~EOT
       Cannot Remove turbolinks from `app/javascript/packs/application.js`
-      Content: require("turbolinks").start()
+      Content: import Turbolinks from 'turbolinks';
+      Content: Turbolinks.start();
     EOT
   end
 


### PR DESCRIPTION
## What happened
Correct the code to remove Turbolink from `application.js` since it doesn't work.

 
## Insight
We don't use [Turbolink](https://github.com/turbolinks/turbolinks) so we remove it when initializing a new project using Rails-template. `app/javascript/packs/application.js` is one of the files we must make the change. We do that in `.template/variants/web/template.rb`:
https://github.com/nimblehq/rails-templates/blob/e077e6726e44411d0dfccbf93c7b1beaf546c769/.template/variants/web/template.rb#L44-L51

 which expects the `application.js` has the following line of code to remove
```javascript
require("turbolinks").start()
```
but it is no longer the case. The code in the file is now:
<img width="449" alt="Screen Shot 2021-01-12 at 11 00 54" src="https://user-images.githubusercontent.com/1896814/104270277-b31bc280-54ca-11eb-9150-d9f9bdc4187f.png">
making the removal code no longer work. Since Turbolink isn't removed, it results in failed (test image) Docker build 
<img width="924" alt="Screen Shot 2021-01-12 at 11 40 00" src="https://user-images.githubusercontent.com/1896814/104270356-e9f1d880-54ca-11eb-8461-cbda788d1ccf.png">
 This PR update the instructions to remove those line of code from `application.js`

## Proof Of Work
Initialize a new project using updated Rails-template, Turbolink is removed from `application.js`
<img width="532" alt="Screen Shot 2021-01-12 at 11 42 29" src="https://user-images.githubusercontent.com/1896814/104270507-40f7ad80-54cb-11eb-8cd1-0d94fe6e800a.png">

 