### PR TITLE
Change the term from `require("channels")` to `import "channels"` on rails 6.1.0

### DIFF
--- a/.template/variants/web/app/template.rb
+++ b/.template/variants/web/app/template.rb
@@ -2,7 +2,7 @@
 directory 'app/javascript'
 
 if File.exist?('app/javascript/packs/application.js')
-  insert_into_file 'app/javascript/packs/application.js', after: %r{require\("channels"\)\n} do
+  insert_into_file 'app/javascript/packs/application.js', after: %r{import "channels"\n} do
     <<~EOT
 
       import 'core-js/stable';


### PR DESCRIPTION
## What happened
On Rails 6.1.0, they changed to `import 'channels';`

 
## Insight
Relative to https://github.com/nimblehq/rails-templates/pull/268
 

## Proof Of Work
The test is passed
 