### PR TITLE
Test doesn't run due to the NGINX configuration

### DIFF
--- a/.template/addons/docker/docker-compose.test.yml.tt
+++ b/.template/addons/docker/docker-compose.test.yml.tt
@@ -49,6 +49,7 @@ services:
       - DB_HOST=db
       - CI=$CI
       - TEST_RETRY=$TEST_RETRY
+      - PORT=$PORT
       - DANGER_GITHUB_API_TOKEN=$DANGER_GITHUB_API_TOKEN
 
 volumes:

--- a/.template/addons/nginx/bin/inject_port_into_nginx.sh
+++ b/.template/addons/nginx/bin/inject_port_into_nginx.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# On Heroku, each web process simply binds to a port, and listens for requests coming in on that port.
+# The port to bind to is assigned by Heroku as the PORT environment variable randomly.
+# We need to point that $PORT into Nginx HTTP listener.
+# https://devcenter.heroku.com/articles/runtime-principles#web-servers
+# https://dev.to/annisalli/deploying-containerized-nginx-to-heroku-how-hard-can-it-be-3g14
+sed -i -e 's/$PORT/'"$PORT"'/g' /etc/nginx/conf.d/default.conf

--- a/.template/addons/nginx/bin/start.sh
+++ b/.template/addons/nginx/bin/start.sh
@@ -1,12 +1,7 @@
 insert_into_file 'bin/start.sh', after: "fi\n" do
   <<-EOT
 
-# On Heroku, each web process simply binds to a port, and listens for requests coming in on that port.
-# The port to bind to is assigned by Heroku as the PORT environment variable randomly.
-# We need to point that $PORT into Nginx HTTP listener.
-# https://devcenter.heroku.com/articles/runtime-principles#web-servers
-# https://dev.to/annisalli/deploying-containerized-nginx-to-heroku-how-hard-can-it-be-3g14
-sed -i -e 's/$PORT/'"$PORT"'/g' /etc/nginx/conf.d/default.conf
+./bin/inject_port_into_nginx.sh
 
 nginx -c /etc/nginx/conf.d/default.conf
   EOT

--- a/.template/addons/nginx/bin/template.rb
+++ b/.template/addons/nginx/bin/template.rb
@@ -1,3 +1,4 @@
 use_source_path __dir__
 
 apply 'start.sh'
+copy_file 'bin/inject_port_into_nginx.sh', mode: :preserve

--- a/.template/spec/addons/base/nginx/template_spec.rb
+++ b/.template/spec/addons/base/nginx/template_spec.rb
@@ -1,10 +1,15 @@
 describe 'Nginx addon - template' do
-  it 'starts nginx in start.sh' do
-    expect(file('bin/start.sh')).to contain('nginx -c /etc/nginx/conf.d/default.conf')
+  it 'creates the inject_port_into_nginx script' do
+    expect(file('bin/inject_port_into_nginx.sh')).to exist
+    expect(file('bin/inject_port_into_nginx.sh')).to be_executable
   end
   
-  it 'sets the HEROKU $PORT as Nginx HTTP listener' do
-    expect(file('bin/start.sh')).to contain(/'sed -i -e 's/$PORT/'"$PORT"'/g' /etc/nginx/conf.d/default.conf/')
+  it 'sets the $PORT as Nginx HTTP listener' do
+    expect(file('bin/start.sh')).to contain('./bin/inject_port_into_nginx.sh')
+  end
+  
+  it 'starts nginx in start.sh' do
+    expect(file('bin/start.sh')).to contain('nginx -c /etc/nginx/conf.d/default.conf')
   end
   
   it 'starts the Puma under PORT 3000' do

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ api_spec = spec/variants/api/**/*_spec.rb
 test_template:
 	cd $(APP_NAME) && \
 	docker-compose -f docker-compose.test.yml up --detach db redis && \
-	docker-compose -f docker-compose.test.yml run test nginx -c /etc/nginx/conf.d/default.conf -t && \
+	docker-compose -f docker-compose.test.yml run test bash -c "./bin/inject_port_into_nginx.sh && nginx -c /etc/nginx/conf.d/default.conf -t" && \
 	docker-compose -f docker-compose.test.yml run --detach test bin/start.sh && \
 	cd ../.template && \
 	bundle install; \


### PR DESCRIPTION
## What happened
Bring the `test template` back

 
## Insight
It happens since we merge the #274, we need to inject the $PORT into the Nginx configuration before running the test
 

## Proof Of Work
1/ Before - The test template spec is not executed

![Pasted_Image_14_01_2021__18_53](https://user-images.githubusercontent.com/11751745/104587675-d47ed900-5699-11eb-9cee-56e75d2d7f74.png)

2/ After - The test template spec is executed

![Pasted_Image_14_01_2021__18_52](https://user-images.githubusercontent.com/11751745/104587581-ad280c00-5699-11eb-9bbc-cb60346e0a0a.png)


 