### PR TITLE
Rename variables.scss to _variables.scss

### DIFF
--- a/.template/spec/variants/web/app/template_spec.rb
+++ b/.template/spec/variants/web/app/template_spec.rb
@@ -32,7 +32,7 @@ describe 'Web variant - /app template' do
         expect(file('app/javascript/packs/application.js')).to contain('import \'regenerator-runtime/runtime\';')
 
         expect(file('app/javascript/packs/application.js')).to contain('import \'translations/translations\';')
-        
+
         expect(file('app/javascript/packs/application.js')).to contain('import \'initializers/\';')
         expect(file('app/javascript/packs/application.js')).to contain('import \'screens/\';')
       end
@@ -40,8 +40,8 @@ describe 'Web variant - /app template' do
   end
 
   context 'Stylesheets' do
-    it 'creates the variables.scss file' do
-      expect(file('app/assets/stylesheets/variables.scss')).to exist
+    it 'creates the _variables.scss file' do
+      expect(file('app/assets/stylesheets/_variables.scss')).to exist
     end
 
     it 'creates the application.scss file' do


### PR DESCRIPTION
## What happened

Rename variables.scss to _variables.scss

## Insight

As per our convention - https://nimblehq.co/compass/development/code-conventions/css/#files

As the file `variables.scss` is imported in `application.scss` it should be renamed to `_variables.scss`

## Proof Of Work

![image](https://user-images.githubusercontent.com/14927672/105277517-c49d5280-5bcd-11eb-819d-191a9495d249.png)
