### PR TITLE
Fix html content matching bug

### DIFF
--- a/.template/variants/web/spec/support/disable_animation.rb
+++ b/.template/variants/web/spec/support/disable_animation.rb
@@ -23,7 +23,7 @@ module Rack
     private
 
     def html?
-      @headers['Content-Type'].include?(/html/)
+      @headers['Content-Type'].include?('html')
     end
 
     # rubocop:disable Metrics/MethodLength


### PR DESCRIPTION
## What happened

Error in system tests while matching HTML content in `disable_animation.rb`

## Insight

In the previous implementation system tests were not running because of wrong matching -

![image](https://user-images.githubusercontent.com/14927672/106234309-cd6fd300-6222-11eb-8006-aa3cb612bc68.png)

After the change, it works as expected.

## Proof Of Work

System tests running seamlessly in our internal project -

![image](https://user-images.githubusercontent.com/14927672/106234329-d95b9500-6222-11eb-931d-f26d1a87de8f.png)
