### PR TITLE
Fix failed system tests with the error Net::ReadTimeout

### DIFF
--- a/.template/variants/web/spec/support/capybara.rb
+++ b/.template/variants/web/spec/support/capybara.rb
@@ -26,6 +26,10 @@ Capybara.register_driver(:headless_chrome) do |app|
   # Because the user namespace is not enabled in the container by default
   options.add_argument('no-sandbox')
 
+  # Disable GPU usage
+  # https://thoughtbot.com/blog/headless-feature-specs-with-chrome#capybara-configuration
+  options.add_argument('disable-gpu')
+
   # Run headless by default unless CHROME_HEADLESS specified
   options.add_argument('headless') unless /^(false|no|0)$/i.match?(ENV['CHROME_HEADLESS'])
 


### PR DESCRIPTION
## What happened

Fix an issue that the system tests when running inside Docker or Github action failed with this error `Net::ReadTimeout`.

## Insight
We saw many failed system tests in the CX project when running on Github action or run the tests inside Docker with this error `Net::ReadTimeout`.
After trying different approaches, we found that adding that argument to capybara fixed it.
```
options.add_argument('disable-gpu')
```
I think something went wrong with the recent Chrome releases but don't know exactly the reason. Besides that, many tutorials of setting capybara on the internet also have that option added so we tried that and it fixed the issue.
https://thoughtbot.com/blog/headless-feature-specs-with-chrome#capybara-configuration

## Proof Of Work

After this fix was made, the system tests works again in CX.
