### PR TITLE
Update Reek config to make it's Rails-friendly when using engines

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -24,6 +24,22 @@ directories:
   "app/mailers":
     InstanceVariableAssumption:
       enabled: false
+  "app/model":
+    InstanceVariableAssumption:
+      enabled: false
+  "engines/**/app/controllers/**":
+    NestedIterators:
+      max_allowed_nesting: 2
+    UnusedPrivateMethod:
+      enabled: false
+    InstanceVariableAssumption:
+      enabled: false
+  "engines/**/app/helpers/**":
+    UtilityFunction:
+      enabled: false
+  "engines/**/app/mailers/**":
+    InstanceVariableAssumption:
+      enabled: false
   "db/migrate/":
     FeatureEnvy:
       enabled: false


### PR DESCRIPTION
## What happened

Update Reek's configuration to make it's Rails-friendly when using engines

## Insight

[Reeks' official documentation](https://github.com/troessner/reek#working-with-rails) recommend to add this to its configuration when working with Rails:
```yml
directories:
  "app/controllers":
    IrresponsibleModule:
      enabled: false
    NestedIterators:
      max_allowed_nesting: 2
    UnusedPrivateMethod:
      enabled: false
    InstanceVariableAssumption:
      enabled: false
  "app/helpers":
    IrresponsibleModule:
      enabled: false
    UtilityFunction:
      enabled: false
  "app/mailers":
    InstanceVariableAssumption:
      enabled: false
  "app/models":
    InstanceVariableAssumption:
      enabled: false
```
This PR adds a missing config for models and also support Rails engines

## Proof Of Work

N/A
