### PR TITLE
Update Rails to v6.1.3.1

### DIFF
--- a/Gemfile.tt
+++ b/Gemfile.tt
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 ruby '<%= RUBY_VERSION %>'
 
 # Backend
-gem 'rails', '6.1.1' # Latest stable
+gem 'rails', '6.1.3.1' # Latest stable
 gem 'pg' # Use Postgresql as database
 gem 'puma' # Use Puma as the app server
 gem 'mini_magick' # A ruby wrapper for ImageMagick or GraphicsMagick command line

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ with building complex applications over the years.
 ### Requirements
 
 - Install ruby and set your local ruby version to `2.7.2`
-- Install rails > `6.0.0`, recommended version `6.1.1`
+- Install rails > `6.0.0`, recommended version `6.1.3.1`
 
 ### Use the template
 


### PR DESCRIPTION
## What happened

Update Rails to the latest stable version v6.1.3.1 to avoid the issue of failing to start because of yanked dependency.

## Insight

Rails depends on the [MimeMagic](https://github.com/mimemagicrb/mimemagic) gem (ActionMailbox -> ActiveStorage -> Marcel -> Mimemagic). But that gem recently yanked all v0.3.x versions, making the new Rails apps fail to start and the old ones fail to rebuild. Mimemagic also released new versions but changed the Licence from MIT -> GPL2 which isn't compatible with Rails' license anymore. 
Rails release a new version v6.1.3.1 to solve that issue by removing Mimemagic dependency.

- https://github.com/rails/rails/issues/41750

- https://github.com/rails/rails/releases/tag/v6.1.3.1

-  https://github.com/rails/marcel/releases/tag/v1.0.0

## Proof Of Work

Nimble CX after upgrading to this version no longer experience the failed build due to `mimemagic` gem.
