### PR TITLE
Set up TypeScript by default

### DIFF
--- a/.template/spec/variants/web/app/template_spec.rb
+++ b/.template/spec/variants/web/app/template_spec.rb
@@ -37,6 +37,12 @@ describe 'Web variant - /app template' do
         expect(file('app/javascript/packs/application.js')).to contain('import \'screens/\';')
       end
     end
+
+    context 'packs/hello_typescript.ts' do
+      it 'creates the default pack file for TypeScript' do
+        expect(file('app/javascript/packs/hello_typescript.ts')).to exist
+      end
+    end
   end
 
   context 'Stylesheets' do

--- a/.template/spec/variants/web/package_json_spec.rb
+++ b/.template/spec/variants/web/package_json_spec.rb
@@ -12,6 +12,11 @@ describe 'Web variant - package.json' do
     it 'adds I18n-js dependency' do
       expect(subject['dependencies']).to include('i18n-js')
     end
+
+    it 'adds typescript dependencies' do
+      expect(subject['dependencies']).to include('@babel/preset-typescript')
+      expect(subject['dependencies']).to include('typescript')
+    end
   end
 
   describe 'Development Dependencies' do

--- a/.template/spec/variants/web/template_spec.rb
+++ b/.template/spec/variants/web/template_spec.rb
@@ -16,6 +16,10 @@ describe 'Web variant - template' do
     expect(file('.npmrc'))
   end
 
+  it 'creates the TypeScript config file' do
+    expect(file('tsconfig.json'))
+  end
+
   context 'Turbolinks' do
     it 'removes data-turbolinks-track attribute from the layout' do
       expect(file('app/views/layouts/application.html.erb')).not_to contain('data-turbolinks-track')

--- a/.template/variants/web/package.json.rb
+++ b/.template/variants/web/package.json.rb
@@ -9,7 +9,7 @@ end
 
 insert_into_file 'package.json', after: %r{"@rails/ujs":.+\n} do
   <<~EOT
-    "i18n-js": "3.5.1",
+    "i18n-js": "3.8.0",
   EOT
 end
 

--- a/.template/variants/web/template.rb
+++ b/.template/variants/web/template.rb
@@ -23,7 +23,10 @@ def apply_web_variant!
   after_bundle do
     use_source_path __dir__
 
-    # Fix the default rails template that does not put trailing commas
+    # Use TypeScript by default
+    rails_command('webpacker:install:typescript')
+
+    # Fix the default Rails template that does not put trailing commas
     run 'yarn run lint --fix'
 
     apply 'config/webpack/template.rb'


### PR DESCRIPTION
## What happened

Set up TypeScript (TS) via Webpacker. I also updated the library `i18n-js` as it was preventing the TS set up to work properly. 

## Insight

As part of the engineering roadmap for 2021, TypeScript is made default for Web projects. Learn more about the decisio on [Notion](https://www.notion.so/nimblehq/Make-TypeScript-default-in-Rails-Template-c40989f8884e48c5bb871912bd0a3c13)) and in [this retrospective presentation](https://docs.google.com/presentation/d/1wRFVS-TXYXacLLjAoyShz1F-Z6lkYrRMl2hgCM9PfTg/edit?usp=sharing).

## Proof Of Work

TypeScript is installed when using the template:

![image](https://user-images.githubusercontent.com/696529/113988336-913b9d00-9879-11eb-8ba7-068766973ef2.png)

When using the default pack tag:

![image](https://user-images.githubusercontent.com/696529/113988467-b4fee300-9879-11eb-8616-cb995e95c0dc.png)

![image](https://user-images.githubusercontent.com/696529/113988498-bc25f100-9879-11eb-86ab-400b27e0f39e.png)
