### PR TITLE
[#295] RFC: Soft delete gem - paranoia or discard

### DIFF
--- a/Gemfile.tt
+++ b/Gemfile.tt
@@ -7,7 +7,7 @@ gem 'pg' # Use Postgresql as database
 gem 'puma' # Use Puma as the app server
 gem 'mini_magick' # A ruby wrapper for ImageMagick or GraphicsMagick command line
 gem 'pagy' # A pagination gem that is very light and fast
-gem 'paranoia' # Paranoia is a re-implementation of acts_as_paranoid for Rails 3 and Rails 4. Soft-deletion of records
+gem 'discard' # Soft deletes for ActiveRecord
 gem 'ffaker' # A library for generating fake data such as names, addresses, and phone numbers.
 gem 'fabrication' # Fabrication generates objects in Ruby. Fabricators are schematics for your objects, and can be created as needed anywhere in your app or specs.
 gem 'sidekiq' # background processing for Ruby


### PR DESCRIPTION
- #295 

## What happened

Replace paranoia gem with discard gem as default soft-delete gem.
Voted in #295 

## Insight

Simple replace in GemFile.tt

## Proof Of Work

![image](https://user-images.githubusercontent.com/77609814/124063512-3fac4400-da5d-11eb-9014-e5e5e7af56d7.png)

