### PR TITLE
#297 Fix: spec/support/disable_annimation.rb nil error for WebSocket requests

### DIFF
--- a/.template/variants/web/spec/support/disable_animation.rb
+++ b/.template/variants/web/spec/support/disable_animation.rb
@@ -23,7 +23,7 @@ module Rack
     private
 
     def html?
-      @headers['Content-Type'].include?('html')
+      @headers['Content-Type']&.include?('html')
     end
 
     # rubocop:disable Metrics/MethodLength


### PR DESCRIPTION
- #297 

## What happened

- Add missing safe navigation operator in `spec/support/disable_annimation.rb` for web variant

## Insight

Change is minimal, steps to reproduce the issue (and so to test) are described in #297 
I've implemented this change in my IC [here](https://github.com/malparty/google-search-ruby/pull/72/files) and it works perfectly.

## Proof Of Work

`N/A`