### PR TITLE
#299 Add system tests Screenshot upload to GitHub Actions

### DIFF
--- a/.template/addons/github/.github/workflows/test.yml.tt
+++ b/.template/addons/github/.github/workflows/test.yml.tt
@@ -88,3 +88,10 @@ jobs:
 
       - name: Run system tests
         run: docker-compose run test bundle exec rspec spec/systems --profile
+
+      - name: Upload system tests screenshots artifact
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: system_tests_screenshots
+          path: tmp/screenshots/*


### PR DESCRIPTION
#299 

## What happened

Added 1 step at the end of the `test` GitHub Action.
This will be triggered only if the tests failed.
It will upload the screenshots made by Rspec into the GitHub Actions artefacts.

## Insight

```yml
- name: Upload system tests screenshots artifact
  uses: actions/upload-artifact@v2
  if: ${{ failure() }}
  with:
    name: system_tests_screenshots
    path: tmp/screenshots/*
```
Code already in used by Elixir Template (cf #299 description).


## Proof Of Work

### Test repository

I have published a fresh project generated from this branch.
Github actions have been configured and you can see [the screenshot uploaded here](https://github.com/malparty/rails_template_test_screenshot/actions/runs/1078143017):

![image](https://user-images.githubusercontent.com/77609814/127473648-228ddd4e-f9e6-4c06-a06b-3b4e528436a8.png)


### Generated test.yml
The generated test.yml includes the step:
![image](https://user-images.githubusercontent.com/77609814/127462755-7b55719f-3d68-4be7-99ea-6ff436a418ed.png)

