### PR TITLE
Add the release Pull request template

### DIFF
--- a/.template/addons/github/.github/PULL_REQUEST_TEMPLATE/RELEASE_TEMPLATE.md
+++ b/.template/addons/github/.github/PULL_REQUEST_TEMPLATE/RELEASE_TEMPLATE.md
@@ -1,0 +1,17 @@
+Link to the milestone on Github e.g. https://github.com/nimblehq/git-templates/milestone/41?closed=1
+or
+Link to the project management tool for the release
+
+## Features
+
+Provide the ID and title of the issue in the section for each type (feature, chore and bug). The link is optional.
+
+- [ch1234] As a user, I can log in
+  or
+- [[ch1234](https://github.com/nimblehq/git-templates/issues/1234)] As a user, I can log in
+
+## Chores
+- Same structure as in  ## Feature
+
+## Bugs
+- Same structure as in  ## Feature

--- a/.template/addons/github/.github/workflows/README.md.tt
+++ b/.template/addons/github/.github/workflows/README.md.tt
@@ -28,16 +28,17 @@ Use the `deploy_heroku.yml` GitHub Action to deploy your app in Heroku.
     - {your-project-name}
     - {your-project-name}-staging
 - If needed, update the `.github\workflow\deploy_heroku.yml` file to matches your Heroku apps names:
+
   ```yml
   [...]
-        - name: Set env HEROKU_APP
-          run: |
-            if [[ $BRANCH_TAG = "latest" ]]
-            then
-              echo "HEROKU_APP=HERE" >> $GITHUB_ENV
-            else
-              echo "HEROKU_APP=HERE-staging" >> $GITHUB_ENV
-            fi
+  - name: Set env HEROKU_APP
+    run: |
+      if [[ $BRANCH_TAG = "latest" ]]
+      then
+        echo "HEROKU_APP=HERE" >> $GITHUB_ENV
+      else
+        echo "HEROKU_APP=HERE-staging" >> $GITHUB_ENV
+      fi
   [...]
 
 > This step might simply be changing '_' to '-' in the app name

--- a/README.md.tt
+++ b/README.md.tt
@@ -15,9 +15,9 @@
 
 ### Docker
 
-* Install [Docker for Mac](https://docs.docker.com/docker-for-mac/install/)
+- Install [Docker for Mac](https://docs.docker.com/docker-for-mac/install/)
 
-* Setup and boot the Docker containers:
+- Setup and boot the Docker containers:
 
 ```sh
 ./bin/envsetup.sh
@@ -25,15 +25,15 @@
 
 ### Development
 
-* Setup the databases:
+- Setup the databases:
 
-  * Postgres:
+  - Postgres:
 
   ```sh
   rake db:setup
   ```
 
-* Run the Rails app
+- Run the Rails app
 
 ```sh
 foreman start -f Procfile.dev
@@ -45,7 +45,7 @@ foreman start -f Procfile.dev
 
 Add the following build settings to run the tests in the Docker environment via Docker Compose (configuration in `docker-compose.test.yml`):
 
-* Configure the environment variable `BRANCH_TAG` to tag Docker images per branch, e.g:
+- Configure the environment variable `BRANCH_TAG` to tag Docker images per branch, e.g:
 
 ```sh
 # a unique `BRANCH_TAG` value to tag the Docker image
@@ -59,7 +59,7 @@ Each branch needs to have its own Docker image to avoid build settings dispariti
 > BRANCH_TAG must not contain special characters (`/`) to be valid. So using $BRANCH_NAME will not work e.g. chore/setup-docker.
 An alternative is to use a unique identifier such as PR_ID or BRANCH_ID on the CI server.
 
-* Pull the latest version the Docker image for the branch:
+- Pull the latest version the Docker image for the branch:
 
 ```sh
 docker pull $DOCKER_IMAGE:$BRANCH_TAG || true
@@ -68,7 +68,7 @@ docker pull $DOCKER_IMAGE:$BRANCH_TAG || true
 On each build, the CI environment does not contain yet a cached version of the image. Therefore, it is required to pull
 it first to leverage the `cache_from` settings of Docker Compose which avoids rebuilding the whole Docker image on subsequent test builds.
 
-* Build the Docker image:
+- Build the Docker image:
 
 ```sh
 ./bin/docker-prepare && docker-compose -f docker-compose.test.yml build
@@ -76,13 +76,13 @@ it first to leverage the `cache_from` settings of Docker Compose which avoids re
 
 Upon the first build, the whole Docker image is built from the ground up and tagged using `$BRANCH_TAG`.
 
-* Push the latest version of the Docker image for this branch:
+- Push the latest version of the Docker image for this branch:
 
 ```sh
 docker push $DOCKER_IMAGE:$BRANCH_TAG
 ```
 
-* Setup the test database:
+- Setup the test database:
 
 ```sh
 docker-compose -f docker-compose.test.yml run test bin/bundle exec rake db:test:prepare
@@ -94,11 +94,11 @@ To setup the semaphore CI 2.0 for the project, please follow [this guideline](.s
 
 #### Github actions & Heroku Deployment
 
-To setup Github actions for the project, please follow [this guideline](.github/README.md)
+To setup Github actions for the project, please follow [this guideline](.github/workflows/README.md)
 
 ### Test
 
-* Run all tests:
+- Run all tests:
 
 ```sh
 # Docker way
@@ -108,7 +108,7 @@ docker-compose -f docker-compose.test.yml run test
 rspec
 ```
 
-* Run a specific test:
+- Run a specific test:
 
 ```sh
 # Docker way


### PR DESCRIPTION
## What happened

Add the Github template for the release pull requests that match our [convention](https://nimblehq.co/compass/development/version-control/release-management/#release-pull-request).

## Insight

The implementation is identical with https://github.com/nimblehq/git-template/pull/15. 
Github supports multiple [templates for issues and pull requests](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates). For example, to define multiple pull request templates, simply define them like this:
```bash
.github
└── PULL_REQUEST_TEMPLATE
    ├── normal_template.md
    └── release_template.md
```

But unlike issue templates - when opening a new issue, Github will show a template selection menu:
<img width="1182" alt="Screen Shot 2021-06-24 at 09 24 41" src="https://user-images.githubusercontent.com/1896814/123192905-02c8d600-d4ce-11eb-8768-2dfd3232bcf3.png">

even with multiple pull request templates defined, a UI to select the template isn't available yet. It is a known issue (read more: [(1)](https://github.community/t/multiple-pull-request-templates/1850), [(2)](https://github.community/t/multiple-pull-request-template/874)). 
As a result, when opening a new pull request, we have to specify the template manually by putting a query param `?template=<template_name.md>` into the pull request URL, e.g. 

`https://github.com/nimblehq/git-template/compare/chore/add-release-pull-request-template?expand=1&`**template=release_template.md**

Also, Github doesn't support setting a default template for new pull requests if putting all templates under `PULL_REQUEST_TEMPLATE` directory

So I ended up organizing the templates like this:
```bash
.github
├── PULL_REQUEST_TEMPLATE
│   └── RELEASE_TEMPLATE.md
└── PULL_REQUEST_TEMPLATE.md
```
with the above structure, when opening a new pull request, without the `?template` param provided, Github still uses the default template defined by `PULL_REQUEST_TEMPLATE.md`. And when we need to use a new template, in this case, the release template, we must specify it in the URL.

## Proof Of Work

I created a test repo. When opening a [new pull request](https://github.com/longnd/awesomedemo/compare/main...chore/template) without the `template` param specified, the default template is used:

<img width="930" alt="Screen Shot 2021-06-24 at 09 36 13" src="https://user-images.githubusercontent.com/1896814/123193820-a23a9880-d4cf-11eb-8287-1113b4246b16.png">

And when specify the template, that template is used:

<img width="968" alt="Screen Shot 2021-06-24 at 09 38 53" src="https://user-images.githubusercontent.com/1896814/123194033-ff364e80-d4cf-11eb-998a-7c765665fc8e.png">


