### PR TITLE
fix(#334): default install_addon_prompt? to No

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -115,7 +115,7 @@ def delete_test_folder
 end
 
 def install_addon_prompt(addon)
-  "Would you like to add the #{addon} addon? [Yn]"
+  "Would you like to add the #{addon} addon? [yN]"
 end
 
 def post_default_addons_install


### PR DESCRIPTION
## Issue
#334 

## What happened

[Yn] default is Yes, [yN] default is No. Generally in CLI prompt capital letter means default value.

## Proof Of Work

**Old Behavior**
![image](https://user-images.githubusercontent.com/4189129/173006257-c2d3970b-769d-478a-a32f-07a62decb8c9.png)


**New Behavior**
![image](https://user-images.githubusercontent.com/4189129/173008105-96dfa643-fe28-4e63-ad55-03b3bef96ea7.png)
