### PR TITLE
[#337] Update PostgreSQL version from 12 to 14

### DIFF
--- a/.template/addons/docker/docker-compose.dev.yml.tt
+++ b/.template/addons/docker/docker-compose.dev.yml.tt
@@ -6,6 +6,7 @@ services:
     container_name: <%= APP_NAME %>_db
     environment:
       - POSTGRES_DB=<%= APP_NAME %>_development
+      - POSTGRES_PASSWORD=postgres
     ports:
       - "5432:5432"
 

--- a/.template/addons/docker/docker-compose.test.yml.tt
+++ b/.template/addons/docker/docker-compose.test.yml.tt
@@ -6,6 +6,7 @@ services:
     container_name: <%= APP_NAME %>_db
     environment:
       - POSTGRES_DB=<%= APP_NAME %>_test
+      - POSTGRES_PASSWORD=postgres
     ports:
       - "5432"
 

--- a/config/application.yml.tt
+++ b/config/application.yml.tt
@@ -3,6 +3,7 @@ default: &default
   DB_HOST: "localhost"
   DB_PORT: "5432"
   DB_USERNAME: "postgres"
+  DB_PASSWORD: "postgres"
   MAILER_DEFAULT_HOST: "localhost"
   MAILER_DEFAULT_PORT: "3000"
   MAILER_SENDER: "Test <noreply@nimblehq.co>"

--- a/config/database.yml
+++ b/config/database.yml
@@ -8,6 +8,7 @@ development:
   host:     <%= ENV['DB_HOST'] %>
   port:     <%= ENV['DB_PORT'] %>
   username: <%= ENV['DB_USERNAME'] %>
+  password: <%= ENV['DB_PASSWORD'] %>
   database: <%= ENV['DB_NAME'] %>_development
 
 test:
@@ -15,6 +16,7 @@ test:
   host:     <%= ENV['DB_HOST'] %>
   port:     <%= ENV['DB_PORT'] %>
   username: <%= ENV['DB_USERNAME'] %>
+  password: <%= ENV['DB_PASSWORD'] %>
   database: <%= ENV['DB_NAME'] %>_test
 
 production:

--- a/template.rb
+++ b/template.rb
@@ -9,7 +9,7 @@ APP_NAME_HUMANIZED = app_name.split(/[-_]/).map(&:capitalize).join(' ').gsub(/ W
 DOCKER_REGISTRY_HOST = 'docker.io'
 DOCKER_IMAGE = "nimblehq/#{APP_NAME}".freeze
 RUBY_VERSION = '3.0.1'
-POSTGRES_VERSION = '12.1'
+POSTGRES_VERSION = '14.4'
 REDIS_VERSION = '5.0.7'
 # Variants
 API_VARIANT = options[:api] || ENV['API'] == 'true'


### PR DESCRIPTION
- Close #337 

## What happened

Update PostgreSQL version from `12.1` to `14.4`

## Insight

- [x] Tested locally with a new project and scaffolding some entities
- [x] Both our Phoenix and Gin templates use Postgres 14 already.

## Proof Of Work

### App Setup

| `envsetup` working | Container is the right version |
|---|---|
| <img width="445" alt="image" src="https://user-images.githubusercontent.com/77609814/177118798-492875d7-48fb-4ff5-9dfd-25fd86335f56.png"> | <img width="464" alt="image" src="https://user-images.githubusercontent.com/77609814/177123524-40287c27-8f6a-4024-8db8-3367682b40a8.png"> |

### After scaffolding some model

| Db migration working | Using the application working |
|---|---|
| <img width="440" alt="image" src="https://user-images.githubusercontent.com/77609814/177124036-5a828aeb-f5af-46f4-8796-f998c8d252ae.png"> | <img width="948" alt="image" src="https://user-images.githubusercontent.com/77609814/177124575-75b6b075-a114-45fd-91b8-51a21540562a.png"> |




