### PR TITLE
[#344] Fix: Test failing since the Hotwire feature

### DIFF
--- a/.template/addons/hotwire/Gemfile.rb
+++ b/.template/addons/hotwire/Gemfile.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Hotwire Rails
 insert_into_file 'Gemfile', after: /gem 'bcrypt'.*\n/ do
   <<~RUBY

--- a/.template/addons/hotwire/template.rb
+++ b/.template/addons/hotwire/template.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 apply '.template/addons/hotwire/Gemfile.rb'

--- a/.template/spec/addons/variants/web/hotwire/gemfile_spec.rb
+++ b/.template/spec/addons/variants/web/hotwire/gemfile_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+describe 'Hotwire Addon - Gemfile' do
+  subject { file('Gemfile') }
+
+  it 'adds turbo-rails gem' do
+    expect(subject).to contain('turbo-rails')
+  end
+
+  it 'adds stimulus-rails gem' do
+    expect(subject).to contain('stimulus-rails')
+  end
+end

--- a/.template/variants/web/template.rb
+++ b/.template/variants/web/template.rb
@@ -24,6 +24,7 @@ def apply_web_variant!
   # Add-ons - [Optional]
   apply '.template/addons/bootstrap/template.rb' if yes? install_addon_prompt 'Bootstrap'
   apply '.template/addons/slim/template.rb' if yes? install_addon_prompt 'Slim Template Engine'
+  apply '.template/addons/hotwire/template.rb' if yes? install_addon_prompt 'Hotwire'
 
   after_bundle do
     use_source_path __dir__

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,9 @@
 common_addon_prompts = Y\nY\nY\nY\nY\n
 
 # Y - in response to Would you like to add the Bootstrap addon?
-# Y - in response to Would you like to add the Slim Template Engine addon?
-web_addon_prompts = Y\nY\n
+# Y - in response to Would you like to add the Slim Template Engine addon?
+# Y - in response to Would you like to add the Hotwire addon?
+web_addon_prompts = Y\nY\nY\n
 
 create_web:
 	printf "${common_addon_prompts}${web_addon_prompts}" | rails new $(APP_NAME) -m ./template.rb -T ${OPTIONS}

--- a/template.rb
+++ b/template.rb
@@ -67,7 +67,6 @@ def apply_template!(template_root)
   post_default_addons_install
 
   # Add-ons - [Optional]
-  apply '.template/addons/hotwire/template.rb' if WEB_VARIANT && yes?(install_addon_prompt('Hotwire'))
   apply '.template/addons/github/template.rb' if yes?(install_addon_prompt('Github Action and Wiki'))
   apply '.template/addons/semaphore/template.rb' if yes?(install_addon_prompt('SemaphoreCI'))
   apply '.template/addons/nginx/template.rb' if yes?(install_addon_prompt('Nginx'))

--- a/template.rb
+++ b/template.rb
@@ -135,7 +135,7 @@ end
 
 # Setup the template root path
 # If the template file is the url, clone the repo to the tmp directory
-template_root = __FILE__ =~ %r{\Ahttps?://} ? remote_repository : __dir__
+template_root = __FILE__.match?(%r{\Ahttps?://}) ? remote_repository : __dir__
 use_source_path template_root
 
 # Init the template helpers


### PR DESCRIPTION
- Close #344 

## What happened 👀

- Add missing frozen string literals
- Run rubocop auto fix (warning it tries to add an `attr_reader` in an unwanted place!)
- Move the prompt for Hotwire with the other "Web Varient Prompts"
- Add the tests for the Hotwire add-ons

## Insight 📝

> ⚠️ When a forked branch PR is submitted, the checks will not run by default and needs to be run manually by a repository owner (after ensuring the GitHub Actions are not corrupted). This is the reason why this PR has been made, to fix issues that we were not aware on a previous external PR.

## Proof Of Work 📹

All tests now pass! ✅ 
![image](https://user-images.githubusercontent.com/77609814/179180610-4386040c-39e3-4804-b291-ecc47874f375.png)

It prompts for Hotwire AFTER the global prompts.
![image](https://user-images.githubusercontent.com/77609814/179179539-49880d11-db52-44ad-9b0c-2395198c596c.png)
