### PR TITLE
[#338] Update Redis version from 5.0.7 to 6.2.7

### DIFF
--- a/.template/addons/docker/docker-compose.yml.tt
+++ b/.template/addons/docker/docker-compose.yml.tt
@@ -10,7 +10,7 @@ services:
       - "5432:5432"
 
   redis:
-    image: redis:5.0.7
+    image: redis:<%= REDIS_VERSION %>
     container_name: <%= APP_NAME %>_redis
     ports:
       - "6379:6379"

--- a/template.rb
+++ b/template.rb
@@ -10,7 +10,7 @@ DOCKER_REGISTRY_HOST = 'docker.io'
 DOCKER_IMAGE = "nimblehq/#{APP_NAME}".freeze
 RUBY_VERSION = '3.0.1'
 POSTGRES_VERSION = '14.4'
-REDIS_VERSION = '5.0.7'
+REDIS_VERSION = '6.2.7'
 # Variants
 API_VARIANT = options[:api] || ENV['API'] == 'true'
 WEB_VARIANT = !API_VARIANT


### PR DESCRIPTION
- Close #338 

## What happened 👀

Update Redis. 

## Insight 📝

Version 6.2 to ensure AWS compatibility. 
Patch 7 is the latest one.

## Proof Of Work 📹

### The template command ran successfully

![image](https://user-images.githubusercontent.com/77609814/180400843-1e7904b1-1d72-471a-9bd9-8b246829a6d3.png)

### `./bin/envsetup` ran well

![image](https://user-images.githubusercontent.com/77609814/180401067-cfe2519b-7a31-42c0-8aaa-378768c1ce82.png)

...resulting in the following containers:

![image](https://user-images.githubusercontent.com/77609814/180401210-a4b0d107-aa7a-4319-988b-fe425ba98dc7.png)

### The app is running

![image](https://user-images.githubusercontent.com/77609814/180401865-bb13d604-d632-4e22-9b6a-3f6a09d5375b.png)
![image](https://user-images.githubusercontent.com/77609814/180401910-74adf4db-c98e-4168-a659-de22f408991d.png)
