### PR TITLE
[#349] Rename master to main

### DIFF
--- a/.template/addons/semaphore/.semaphore/semaphore.yml.tt
+++ b/.template/addons/semaphore/.semaphore/semaphore.yml.tt
@@ -7,7 +7,7 @@ agent:
     os_image: ubuntu1804
 auto_cancel:
   running:
-    when: "branch != 'master'"
+    when: "branch != 'main'"
 
 global_job_config:
   env_vars:
@@ -28,7 +28,7 @@ blocks:
         - name: Build
           commands:
             - >-
-              if ([ $SEMAPHORE_GIT_BRANCH != 'master' ] && [ $SEMAPHORE_GIT_BRANCH != 'development' ]);
+              if ([ $SEMAPHORE_GIT_BRANCH != 'main' ] && [ $SEMAPHORE_GIT_BRANCH != 'development' ]);
                 then (echo "Pulling built image for the branch"; docker compose pull test || true);
                 else (echo "Skipping docker pull");
               fi || true
@@ -67,4 +67,4 @@ promotions:
   - name: Production
     pipeline_file: promotion-production.yml
     auto_promote:
-      when: "branch = 'master' AND result = 'passed'"
+      when: "branch = 'main' AND result = 'passed'"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ with building complex applications over the years.
 In order to use the template, initialize a new app with the following parameters:
 
 ```sh
-rails new <app_name> -m https://raw.githubusercontent.com/nimblehq/rails-templates/master/template.rb
+rails new <app_name> -m https://raw.githubusercontent.com/nimblehq/rails-templates/main/template.rb
 ```
 
 Supported template options:
@@ -36,13 +36,13 @@ Supported template options:
 To apply the template on an existing application, run following rails command:
 
 ```sh
-rails app:template LOCATION=https://raw.githubusercontent.com/nimblehq/rails-templates/master/template.rb
+rails app:template LOCATION=https://raw.githubusercontent.com/nimblehq/rails-templates/main/template.rb
 
 # To apply on an api application
-rails app:template LOCATION=https://raw.githubusercontent.com/nimblehq/rails-templates/master/template.rb API=true
+rails app:template LOCATION=https://raw.githubusercontent.com/nimblehq/rails-templates/main/template.rb API=true
 
 # To apply a specific addon
-rails app:template LOCATION=https://raw.githubusercontent.com/nimblehq/rails-templates/master/template.rb ADDON=<addon name>
+rails app:template LOCATION=https://raw.githubusercontent.com/nimblehq/rails-templates/main/template.rb ADDON=<addon name>
 ```
 
 Available Addons:

--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -12,7 +12,7 @@ Rails.backtrace_cleaner.remove_silencers!
 # Add backtrace silencer
 # Default silencer is removing backtrace involving engines files
 # Our silencer also checks for engines directory
-# Ref: https://github.com/rails/rails/blob/master/railties/lib/rails/backtrace_cleaner.rb
+# Ref: https://github.com/rails/rails/blob/main/railties/lib/rails/backtrace_cleaner.rb
 Rails.backtrace_cleaner.add_silencer do |line|
   !(Rails::BacktraceCleaner::APP_DIRS_PATTERN.match?(line) || /^engines/.match?(line))
 end


### PR DESCRIPTION
- Close #349 

## What happened 👀

This PR only handles the reference renaming. The real rename of the branch will be done at the time of the release.

## Insight 📝

Some workflow had both references to master and main so I kept both. For workflows that had only `master`, I changed them to `main` (as for example I cannot test the Circle CI pipeline at the moment, so I don't want to introduce a bug by adding some logic like `master || main`). 

Rails repository also renamed its branches, that is the reason why their is 1 renaming on the rails repository URL too 😇 

## Proof Of Work 📹

Simple renaming so the `files changed` section is the best! ;-) 
