### PR TITLE
[#191] Add a default database adapter for production environment

### DIFF
--- a/.github/workflows/test_variants.yml
+++ b/.github/workflows/test_variants.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           export BRANCH_TAG=${{ env.BRANCH_TAG }}-${{ matrix.variant }}
           cd $APP_NAME
-          docker compose pull test || true
+          docker-compose pull test || true
 
       - name: Build docker image
         run: |
@@ -98,7 +98,7 @@ jobs:
         run: |
           export BRANCH_TAG=${{ env.BRANCH_TAG }}-${{ matrix.variant }}
           cd $APP_NAME
-          docker compose push test
+          docker-compose push test
 
       - name: Test template
         run: |

--- a/Makefile
+++ b/Makefile
@@ -19,16 +19,16 @@ create_api:
 build:
 	cd $(APP_NAME) && \
 	bin/docker-prepare && \
-	docker compose -f docker-compose.test.yml build
+	docker-compose -f docker-compose.test.yml build
 
 build_production:
 	cd $(APP_NAME) && \
 	bin/docker-prepare && \
-	docker compose build
+	docker-compose build
 
 test_variant_app:
 	cd $(APP_NAME) && \
-	docker compose -f docker-compose.test.yml run test
+	docker-compose -f docker-compose.test.yml run test
 
 base_addon_spec = spec/addons/base/**/*_spec.rb
 web_addon_spec = spec/addons/variants/web/**/*_spec.rb
@@ -40,9 +40,9 @@ api_spec = spec/variants/api/**/*_spec.rb
 
 test_template:
 	cd $(APP_NAME) && \
-	docker compose -f docker-compose.test.yml up --detach db redis && \
-	docker compose -f docker-compose.test.yml run test bash -c "./bin/inject_port_into_nginx.sh && nginx -c /etc/nginx/conf.d/default.conf -t" && \
-	docker compose -f docker-compose.test.yml run --detach test bin/start.sh && \
+	docker-compose -f docker-compose.test.yml up --detach db redis && \
+	docker-compose -f docker-compose.test.yml run test bash -c "./bin/inject_port_into_nginx.sh && nginx -c /etc/nginx/conf.d/default.conf -t" && \
+	docker-compose -f docker-compose.test.yml run --detach test bin/start.sh && \
 	cd ../.template && \
 	bundle install; \
 	if [ $(VARIANT) = web ]; then \

--- a/bin/docker-assets-precompile
+++ b/bin/docker-assets-precompile
@@ -8,6 +8,7 @@
 # And it requires the envs as we always use `ENV.fetch` to setup the variables
 #
 # Related issue: https://github.com/rails/rails/issues/32947
+# TODO: https://github.com/nimblehq/rails-templates/issues/326
 
 require 'yaml'
 

--- a/bin/docker-assets-precompile
+++ b/bin/docker-assets-precompile
@@ -16,6 +16,8 @@ rails_env = ENV.fetch('RAILS_ENV', 'production')
 if rails_env == 'production'
   env_keys = YAML.load_file('config/application.yml')['docker_build'].keys
   env_keys.each { |name| ENV[name] = 'dummy_value' }
+
+  ENV['DATABASE_URL'] = 'postgres://postgres:postgres@postgres:5432/postgres'
 end
 
 exit system('bin/rails i18n:js:export && bin/rails assets:precompile')


### PR DESCRIPTION
- Close #191

## What happened 👀

 Add the DATABASE_URL variable in the docker-assets-precompile script

## Insight 📝

All insights are discussed in the issue (#191)
All credits to Hoang for finding a clean fix!!


## Proof Of Work 📹

Tested on the EWA-Payroll project (as we already have the CI set up)

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/77609814/184322448-33324a58-29b7-403e-9379-288b90af0288.png) | ![image](https://user-images.githubusercontent.com/77609814/184322403-db61413a-9552-4a38-b6b1-c795d6f9d61c.png) |
| ![image](https://user-images.githubusercontent.com/77609814/184321731-e51f1d86-4121-49b3-8079-6dfadcd53cb8.png) | ![image](https://user-images.githubusercontent.com/77609814/184322344-62a58ed0-81b6-4430-84d7-c6d70e11518a.png) |

