### PR TITLE
[#352] Fix: `ArgumentError: unknown keyword: :desired_capabilities` when running system tests with the headless_chrome driver

### DIFF
--- a/.github/workflows/test_variants.yml
+++ b/.github/workflows/test_variants.yml
@@ -8,7 +8,7 @@ env:
   DOCKER_IMAGE: ${{ github.repository }}
   DOCKER_REGISTRY_HOST: ${{ secrets.DOCKER_REGISTRY_HOST }}
   DOCKER_REGISTRY_USERNAME: ${{ github.repository_owner }}
-  DOCKER_REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  DOCKER_REGISTRY_TOKEN: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
   RUBY_VERSION: 3.0.1
   NODE_VERSION: 16
   RAILS_VERSION: 7.0.1
@@ -87,7 +87,7 @@ jobs:
         run: |
           export BRANCH_TAG=${{ env.BRANCH_TAG }}-${{ matrix.variant }}
           cd $APP_NAME
-          docker compose pull test || true
+          docker-compose pull test || true
 
       - name: Build docker image
         run: |
@@ -98,7 +98,7 @@ jobs:
         run: |
           export BRANCH_TAG=${{ env.BRANCH_TAG }}-${{ matrix.variant }}
           cd $APP_NAME
-          docker compose push test
+          docker-compose push test
 
       - name: Test template
         run: |

--- a/.github/workflows/test_variants.yml
+++ b/.github/workflows/test_variants.yml
@@ -8,7 +8,7 @@ env:
   DOCKER_IMAGE: ${{ github.repository }}
   DOCKER_REGISTRY_HOST: ${{ secrets.DOCKER_REGISTRY_HOST }}
   DOCKER_REGISTRY_USERNAME: ${{ github.repository_owner }}
-  DOCKER_REGISTRY_TOKEN: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
+  DOCKER_REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   RUBY_VERSION: 3.0.1
   NODE_VERSION: 16
   RAILS_VERSION: 7.0.1

--- a/.template/variants/web/spec/support/capybara.rb
+++ b/.template/variants/web/spec/support/capybara.rb
@@ -9,16 +9,6 @@ CAPYBARA_TIMEOUT = ENV['CI'] ? 60 : 30
 
 # https://github.com/rails/rails/pull/30876
 Capybara.register_driver(:headless_chrome) do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    # This enables access to logs with `page.driver.manage.get_log(:browser)`
-    loggingPrefs: {
-      browser: 'ALL',
-      client: 'ALL',
-      driver: 'ALL',
-      server: 'ALL'
-    }
-  )
-
   options = Selenium::WebDriver::Chrome::Options.new
 
   # Sets default window size in case the smaller default size is not enough
@@ -41,7 +31,6 @@ Capybara.register_driver(:headless_chrome) do |app|
   Capybara::Selenium::Driver.new(
     app,
     browser: :chrome,
-    desired_capabilities: capabilities,
     options: options
   )
 end

--- a/Makefile
+++ b/Makefile
@@ -19,16 +19,16 @@ create_api:
 build:
 	cd $(APP_NAME) && \
 	bin/docker-prepare && \
-	docker compose -f docker-compose.test.yml build
+	docker-compose -f docker-compose.test.yml build
 
 build_production:
 	cd $(APP_NAME) && \
 	bin/docker-prepare && \
-	docker compose build
+	docker-compose build
 
 test_variant_app:
 	cd $(APP_NAME) && \
-	docker compose -f docker-compose.test.yml run test
+	docker-compose -f docker-compose.test.yml run test
 
 base_addon_spec = spec/addons/base/**/*_spec.rb
 web_addon_spec = spec/addons/variants/web/**/*_spec.rb
@@ -40,9 +40,9 @@ api_spec = spec/variants/api/**/*_spec.rb
 
 test_template:
 	cd $(APP_NAME) && \
-	docker compose -f docker-compose.test.yml up --detach db redis && \
-	docker compose -f docker-compose.test.yml run test bash -c "./bin/inject_port_into_nginx.sh && nginx -c /etc/nginx/conf.d/default.conf -t" && \
-	docker compose -f docker-compose.test.yml run --detach test bin/start.sh && \
+	docker-compose -f docker-compose.test.yml up --detach db redis && \
+	docker-compose -f docker-compose.test.yml run test bash -c "./bin/inject_port_into_nginx.sh && nginx -c /etc/nginx/conf.d/default.conf -t" && \
+	docker-compose -f docker-compose.test.yml run --detach test bin/start.sh && \
 	cd ../.template && \
 	bundle install; \
 	if [ $(VARIANT) = web ]; then \


### PR DESCRIPTION
- Close #352 

## What happened 👀

- Remove the deprecated desired_capabilities from the capybara config

## Insight 📝

The `desired_capabilities` was deprecated quite some time ago and ended up being removed from the newer versions of our dependencies. 
We did not find another place to configure the logs (`ALL` everywhere). But we believe such a configuration is not a must-have and we can do without it. Feel free to challenge and suggest improvements! :) 

## Proof Of Work 📹

| Before | After |
|---|---|
|![image](https://user-images.githubusercontent.com/77609814/184325510-04f4b963-389a-4da3-98a7-b5bc26597c8d.png)|![image](https://user-images.githubusercontent.com/77609814/184325566-3acfbb0b-f270-4299-b457-d6f9c104a233.png)|
|![image](https://user-images.githubusercontent.com/77609814/184325471-42989e92-bcff-48bf-a14e-dedf9c24b280.png)|![image](https://user-images.githubusercontent.com/77609814/184325674-91b2d613-fd15-4975-b16b-ba871359fcac.png)|

