### PR TITLE
[#366] Update the sizing function to solve the deprecation warning on using `/` for division

### DIFF
--- a/.template/variants/web/app/assets/stylesheets/functions/_sizing.scss
+++ b/.template/variants/web/app/assets/stylesheets/functions/_sizing.scss
@@ -5,7 +5,7 @@
     @if ($value == 0 or $value == auto) {
       $list: append($list, $value);
     } @else {
-      $em-value: ($value / $base-font-size) + em;
+      $em-value: calc($value / $base-font-size) + em;
       $list: append($list, $em-value);
     }
   }
@@ -20,7 +20,7 @@
     @if ($value == 0 or $value == auto) {
       $list: append($list, $value);
     } @else {
-      $rem-value: ($value / $base-font-size) + rem;
+      $rem-value: calc($value / $base-font-size) + rem;
       $list: append($list, $rem-value);
     }
   }


### PR DESCRIPTION
https://github.com/nimblehq/rails-templates/issues/366

## What happened 👀

Small update on the sizing function, using `calc` to remove deprecate warning from [Dart SASS](https://github.com/sass/dart-sass/) about [using the `/` for division](https://sass-lang.com/documentation/breaking-changes/slash-div)
![Screen Shot 2565-09-26 at 15 14 18](https://user-images.githubusercontent.com/1772999/192271281-9fb6e93e-3e70-4b6f-b5fd-c9efb23628ff.png)

## Insight 📝

N/A

## Proof Of Work 📹

After applying the change the warning gone


https://user-images.githubusercontent.com/1772999/193492716-f9abedae-ce2f-4557-a50a-289aa4526c41.mov

