### PR TITLE
[#363] Fix: Remove the "Has missing safe method" check from the Danger code review

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -4,6 +4,8 @@
 detectors:
   IrresponsibleModule:
     enabled: false
+  MissingSafeMethod:
+    enabled: false
 
   DataClump:
     max_copies: 3


### PR DESCRIPTION
- Close #363 

## What happened 👀

Just disabled that check :) 

Reason: We do not always have a pair of safe() and (un)safe!() method in our code. 
Example: `authorized!` is often used in controllers as per our conventions but we do not have the safe `authorize` equivalent.

## Insight 📝

`n/a`

## Proof Of Work 📹

Tested in our internal projects, we do not have this spam anymore! 👍 

| Before | After |
|---|---|
|![image](https://user-images.githubusercontent.com/77609814/195786941-d2204611-c430-4c61-8854-1a21816fc358.png)|![image](https://user-images.githubusercontent.com/77609814/195787532-5929a5b0-e2ba-423e-a406-138bfcff3db9.png)|
