### PR TITLE
[#362] Fix: Rubocop prevent multi except tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,3 +44,9 @@ RSpec/ContextWording:
   Prefixes:
     - when
     - given
+
+RSpec/NestedGroups:
+  Max: 5
+
+RSpec/MultipleExpectations:
+  Max: 10


### PR DESCRIPTION
- Close #362 

## What happened 👀

Add 2 Rubocop rules to allow 10 expectations per spec and 5 nested blocks.

## Insight 📝

`n/a`

## Proof Of Work 📹

Quite straightforward. Tested in our current project. 😇 