### PR TITLE
[#372] Chore: Update deprecated set-output with GITHUB_OUTPUT environment file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Team
 # @malparty is the Team Lead and the others are team members
-* @rosle @andyduong1920 @bterone @byhbt @carryall @hanam1ni @hoangmirs @junan @Lahphim @longnd @malparty @tyrro
+* @rosle @andyduong1920 @bterone @byhbt @carryall @hanam1ni @hoangmirs @longnd @malparty @tyrro @sanG-github
 
 # Engineering Leads
 CODEOWNERS @nimblehq/engineering-leads

--- a/.github/workflows/test_production_build.yml
+++ b/.github/workflows/test_production_build.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set env BRANCH_TAG
-        uses: nimblehq/branch-tag-action@1.3.0
+        uses: nimblehq/branch-tag-action@1
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/test_production_build.yml
+++ b/.github/workflows/test_production_build.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
 
       - name: Set env BRANCH_TAG
         uses: nimblehq/branch-tag-action@1.3.0
@@ -35,12 +35,12 @@ jobs:
           bundler-cache: true
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.1.4
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Cache gems
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /home/runner/.rubies/ruby-${{ env.RUBY_VERSION }}
           key: ${{ runner.os }}-gems-${{ env.RUBY_VERSION }}-${{ hashFiles('**/Gemfile.lock') }}
@@ -57,7 +57,7 @@ jobs:
 
       - name: Cache npm packages
         if: ${{ matrix.variant == 'web' }}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ${{ steps.yarn-cache-dir-path.outputs.yarn_cache_dir }}

--- a/.github/workflows/test_production_build.yml
+++ b/.github/workflows/test_production_build.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2.3.4
 
       - name: Set env BRANCH_TAG
-        uses: nimblehq/branch-tag-action@v1.2
+        uses: nimblehq/branch-tag-action@1.3.0
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -53,7 +53,7 @@ jobs:
       - name: Get yarn cache directory path
         if: ${{ matrix.variant == 'web' }}
         id: yarn-cache-dir-path
-        run: echo "::set-output name=yarn_cache_dir::$(yarn cache dir)"
+        run: echo "yarn_cache_dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache npm packages
         if: ${{ matrix.variant == 'web' }}

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -17,7 +17,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout Repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -26,7 +26,7 @@ jobs:
           bundler-cache: true
 
       - name: Cache gems
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-template-${{ env.RUBY_VERSION }}-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/test_variants.yml
+++ b/.github/workflows/test_variants.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set env BRANCH_TAG
-        uses: nimblehq/branch-tag-action@1.3.0
+        uses: nimblehq/branch-tag-action@1
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/test_variants.yml
+++ b/.github/workflows/test_variants.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v2.3.4
 
       - name: Set env BRANCH_TAG
-        uses: nimblehq/branch-tag-action@v1.2
+        uses: nimblehq/branch-tag-action@1.3.0
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -56,7 +56,7 @@ jobs:
       - name: Get yarn cache directory path
         if: ${{ matrix.variant == 'web' }}
         id: yarn-cache-dir-path
-        run: echo "::set-output name=yarn_cache_dir::$(yarn cache dir)"
+        run: echo "yarn_cache_dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache npm packages
         if: ${{ matrix.variant == 'web' }}

--- a/.github/workflows/test_variants.yml
+++ b/.github/workflows/test_variants.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
 
       - name: Set env BRANCH_TAG
         uses: nimblehq/branch-tag-action@1.3.0
@@ -38,12 +38,12 @@ jobs:
           bundler-cache: true
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.1.4
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Cache gems
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /home/runner/.rubies/ruby-${{ env.RUBY_VERSION }}
           key: ${{ runner.os }}-gems-${{ env.RUBY_VERSION }}-${{ hashFiles('**/Gemfile.lock') }}
@@ -60,7 +60,7 @@ jobs:
 
       - name: Cache npm packages
         if: ${{ matrix.variant == 'web' }}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ${{ steps.yarn-cache-dir-path.outputs.yarn_cache_dir }}
@@ -76,7 +76,7 @@ jobs:
           make create_${{ matrix.variant }}
 
       - name: Login to docker registry
-        uses: docker/login-action@v1.6.0
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.DOCKER_REGISTRY_HOST }}
           username: ${{ env.DOCKER_REGISTRY_USERNAME }}

--- a/.template/addons/github/.github/workflows/deploy_heroku.yml.tt
+++ b/.template/addons/github/.github/workflows/deploy_heroku.yml.tt
@@ -34,7 +34,7 @@ jobs:
           ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
       - name: Set env BRANCH_TAG
-        uses: nimblehq/branch-tag-action@1.3.0
+        uses: nimblehq/branch-tag-action@1
         with:
           ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 

--- a/.template/addons/github/.github/workflows/deploy_heroku.yml.tt
+++ b/.template/addons/github/.github/workflows/deploy_heroku.yml.tt
@@ -34,7 +34,7 @@ jobs:
           ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
       - name: Set env BRANCH_TAG
-        uses: nimblehq/branch-tag-action@v1.2
+        uses: nimblehq/branch-tag-action@1.3.0
         with:
           ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 

--- a/.template/addons/github/.github/workflows/deploy_heroku.yml.tt
+++ b/.template/addons/github/.github/workflows/deploy_heroku.yml.tt
@@ -29,7 +29,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
@@ -48,7 +48,7 @@ jobs:
           fi
 
       - name: Login to Docker registry
-        uses: docker/login-action@v1.6.0
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.DOCKER_REGISTRY_HOST }}
           username: ${{ env.DOCKER_REGISTRY_USERNAME }}

--- a/.template/addons/github/.github/workflows/test.yml.tt
+++ b/.template/addons/github/.github/workflows/test.yml.tt
@@ -34,7 +34,7 @@ jobs:
         uses: nimblehq/branch-tag-action@1.3.0
 
       - name: Login to Docker registry
-        uses: docker/login-action@v1.6.0
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.DOCKER_REGISTRY_HOST }}
           username: ${{ env.DOCKER_REGISTRY_USERNAME }}
@@ -61,7 +61,7 @@ jobs:
         uses: nimblehq/branch-tag-action@1.3.0
 
       - name: Login to Docker registry
-        uses: docker/login-action@v1.6.0
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.DOCKER_REGISTRY_HOST }}
           username: ${{ env.DOCKER_REGISTRY_USERNAME }}
@@ -90,7 +90,7 @@ jobs:
         uses: nimblehq/branch-tag-action@1.3.0
 
       - name: Login to Docker registry
-        uses: docker/login-action@v1.6.0
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.DOCKER_REGISTRY_HOST }}
           username: ${{ env.DOCKER_REGISTRY_USERNAME }}

--- a/.template/addons/github/.github/workflows/test.yml.tt
+++ b/.template/addons/github/.github/workflows/test.yml.tt
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set env BRANCH_TAG
-        uses: nimblehq/branch-tag-action@1.3.0
+        uses: nimblehq/branch-tag-action@1
 
       - name: Login to Docker registry
         uses: docker/login-action@v2
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set env BRANCH_TAG
-        uses: nimblehq/branch-tag-action@1.3.0
+        uses: nimblehq/branch-tag-action@1
 
       - name: Login to Docker registry
         uses: docker/login-action@v2
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set env BRANCH_TAG
-        uses: nimblehq/branch-tag-action@1.3.0
+        uses: nimblehq/branch-tag-action@1
 
       - name: Login to Docker registry
         uses: docker/login-action@v2

--- a/.template/addons/github/.github/workflows/test.yml.tt
+++ b/.template/addons/github/.github/workflows/test.yml.tt
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set env BRANCH_TAG
-        uses: nimblehq/branch-tag-action@v1.2
+        uses: nimblehq/branch-tag-action@1.3.0
 
       - name: Login to Docker registry
         uses: docker/login-action@v1.6.0
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set env BRANCH_TAG
-        uses: nimblehq/branch-tag-action@v1.2
+        uses: nimblehq/branch-tag-action@1.3.0
 
       - name: Login to Docker registry
         uses: docker/login-action@v1.6.0
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set env BRANCH_TAG
-        uses: nimblehq/branch-tag-action@v1.2
+        uses: nimblehq/branch-tag-action@1.3.0
 
       - name: Login to Docker registry
         uses: docker/login-action@v1.6.0

--- a/.template/addons/github/.github/workflows/test_production_build.yml.tt
+++ b/.template/addons/github/.github/workflows/test_production_build.yml.tt
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set env BRANCH_TAG
-        uses: nimblehq/branch-tag-action@1.3.0
+        uses: nimblehq/branch-tag-action@1
 
       - name: Build Docker image
         run: bin/docker-prepare && docker compose build

--- a/.template/addons/github/.github/workflows/test_production_build.yml.tt
+++ b/.template/addons/github/.github/workflows/test_production_build.yml.tt
@@ -21,7 +21,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
 
       - name: Set env BRANCH_TAG
         uses: nimblehq/branch-tag-action@1.3.0

--- a/.template/addons/github/.github/workflows/test_production_build.yml.tt
+++ b/.template/addons/github/.github/workflows/test_production_build.yml.tt
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2.3.4
 
       - name: Set env BRANCH_TAG
-        uses: nimblehq/branch-tag-action@v1.2
+        uses: nimblehq/branch-tag-action@1.3.0
 
       - name: Build Docker image
         run: bin/docker-prepare && docker compose build

--- a/README.md.tt
+++ b/README.md.tt
@@ -50,7 +50,7 @@ Add the following build settings to run the tests in the Docker environment via 
 ```sh
 # a unique `BRANCH_TAG` value to tag the Docker image
 # e.g $SEMAPHORE_BRANCH_ID or using the
-# or using nimblehq/branch-tag-action@v1.2 Github action
+# or using nimblehq/branch-tag-action@1.3.0 Github action
 export BRANCH_TAG= # unique value for tagging Docker image
 ```
 

--- a/README.md.tt
+++ b/README.md.tt
@@ -50,7 +50,7 @@ Add the following build settings to run the tests in the Docker environment via 
 ```sh
 # a unique `BRANCH_TAG` value to tag the Docker image
 # e.g $SEMAPHORE_BRANCH_ID or using the
-# or using nimblehq/branch-tag-action@1.3.0 Github action
+# or using nimblehq/branch-tag-action@1 Github action
 export BRANCH_TAG= # unique value for tagging Docker image
 ```
 


### PR DESCRIPTION
- close #372 

## What happened 👀

Replace ::set-output with >> $GITHUB_OUTPUT and update actions

## Insight 📝

We can now use the `nimblehq/branch-tag-action@1` (instead of `@1.3.0`) thanks to a major version tag added, that will be maintained with each minor version increment.

## Proof Of Work 📹

- [x] Tests are passing.
- [x] This change is working our client project
