### PR TITLE
[#380] Fix: esbuild 0.17.X has different interface to implement the watch argument

### DIFF
--- a/.template/variants/web/app/javascript/build.js
+++ b/.template/variants/web/app/javascript/build.js
@@ -1,13 +1,17 @@
 const watch = process.argv.slice(2).includes('--watch');
 
-require('esbuild').build({
-  entryPoints: ['app/javascript/application.js'],
-  inject: ['app/javascript/global.js'],
-  bundle: true,
-  sourcemap: true,
-  watch: watch,
-  outdir: 'app/assets/builds',
-}).catch((error) => {
-  console.error(error);
-  process.exit(1);
-});
+require('esbuild')
+  .context({
+    entryPoints: ['app/javascript/application.js'],
+    inject: ['app/javascript/global.js'],
+    bundle: true,
+    sourcemap: true,
+    outdir: 'app/assets/builds',
+  })
+  .then((ctx) => {
+    watch ? ctx.watch() : ctx.rebuild().then(() => process.exit(0));
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
- close #380

## What happened 👀

Fix esbuild watch implementation for v0.17.*

## Insight 📝

> **Note** I'm not "locking" the package.json to a specific version of `esbuild` as I believe it is better to be aware of these errors while working on long-term improvement of the template, rather than realizing that a client project was scaffolded with outdated versions.

## Proof Of Work 📹

### Tests:

Test are passing ✅ 

### Web variant project generated from this fix:

| js.1 | web.1 | 
|---|---|
|<img width="584" alt="image" src="https://user-images.githubusercontent.com/77609814/216885149-fd831bbf-4f51-4ae1-9bdb-968e8d3f0faa.png">|<img width="495" alt="image" src="https://user-images.githubusercontent.com/77609814/216885112-1a039b3c-c2ba-4eda-bec7-772a02976412.png">|

The console has no error, stimulus is well compiled and running as expected:

<img width="774" alt="image" src="https://user-images.githubusercontent.com/77609814/216885497-4c1028d8-3bd9-404e-a6f3-72414921c186.png">

I also tested:
- While watch, edit the controller, the build is regenerated ✅ 
- While having stop the watch (CTR+C after `bin/dev`), it stops the watch ✅ 
- running `node app/javascript/build.js` or `yarn build` will re-build the JS as expected ✅ 

<img width="407" alt="image" src="https://user-images.githubusercontent.com/77609814/216886609-46673df8-de6c-4997-89d3-8ae3a840ca70.png">
