### PR TITLE
[#389] Update Bootstrap 5.1.3 to 5.2.3 to resolve deprecated issues

### DIFF
--- a/.template/addons/bootstrap/package.json.rb
+++ b/.template/addons/bootstrap/package.json.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-run 'yarn add bootstrap@5.1.3'
+run 'yarn add bootstrap@5.2.3'
 run 'yarn add @popperjs/core@2.11.2'

--- a/.template/addons/bootstrap/stylesheets/vendor/_bootstrap.scss
+++ b/.template/addons/bootstrap/stylesheets/vendor/_bootstrap.scss
@@ -5,7 +5,10 @@
 
 // Configuration
 @import 'bootstrap/scss/functions';
+// @import 'variables'; // Optional variable overrides here
 @import 'bootstrap/scss/variables';
+@import 'bootstrap/scss/maps';
+// @import 'sass_maps'; // Optional Sass map overrides here
 @import 'bootstrap/scss/mixins';
 @import 'bootstrap/scss/utilities';
 

--- a/.template/addons/bootstrap/stylesheets/vendor/_bootstrap.scss
+++ b/.template/addons/bootstrap/stylesheets/vendor/_bootstrap.scss
@@ -5,10 +5,11 @@
 
 // Configuration
 @import 'bootstrap/scss/functions';
-// @import 'variables'; // Optional variable overrides here
 @import 'bootstrap/scss/variables';
 @import 'bootstrap/scss/maps';
-// @import 'sass_maps'; // Optional Sass map overrides here
+// @import 'sass_maps'; // Optional Sass map overrides here (See: https://getbootstrap.com/docs/5.2/migration/#new-_mapsscss)
+// e.g., $theme-colors: map-merge($theme-colors, $custom-theme-colors);
+
 @import 'bootstrap/scss/mixins';
 @import 'bootstrap/scss/utilities';
 


### PR DESCRIPTION
- close #389

## What happened 👀

Update bootstrap 5.1.3 to 5.2.3

## Insight 📝

Added import guidances in comments following the [Bootstrap documentation](https://getbootstrap.com/docs/5.2/migration/#new-_mapsscss).

<img width="391" alt="image" src="https://user-images.githubusercontent.com/77609814/218666444-08c32ad6-1d16-48f6-b5cf-cb2e9d1f751d.png">


## Proof Of Work 📹

### CSS can build:

<img width="880" alt="image" src="https://user-images.githubusercontent.com/77609814/218671274-f10afb0f-2263-4074-9a34-4e409a575e2d.png">

### Project run and can refer to bootstrap classes:

_Example provided with margins, form-control and buttons_

<img width="455" alt="image" src="https://user-images.githubusercontent.com/77609814/218671993-90206c6b-dc9d-48ca-8cfb-b13908011009.png">

