### PR TITLE
[#378] Feature: Convert `cancel-workflow-action` to native `concurrency`

### DIFF
--- a/.github/workflows/test_generated_app.yml
+++ b/.github/workflows/test_generated_app.yml
@@ -15,7 +15,7 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/.github/workflows/test_generated_app.yml
+++ b/.github/workflows/test_generated_app.yml
@@ -13,6 +13,10 @@ env:
   NODE_VERSION: 16
   RAILS_VERSION: 7.0.1
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   test:
     name: ${{ matrix.variant }} variant
@@ -21,11 +25,6 @@ jobs:
       matrix:
         variant: [web, api]
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
-
       - uses: actions/checkout@v3
 
       - name: Set env BRANCH_TAG

--- a/.github/workflows/test_production_build.yml
+++ b/.github/workflows/test_production_build.yml
@@ -10,6 +10,10 @@ env:
   NODE_VERSION: 16
   RAILS_VERSION: 7.0.1
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build_production:
     name: ${{ matrix.variant }} variant
@@ -18,11 +22,6 @@ jobs:
       matrix:
         variant: [web, api]
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
-
       - uses: actions/checkout@v3
 
       - name: Set env BRANCH_TAG

--- a/.github/workflows/test_production_build.yml
+++ b/.github/workflows/test_production_build.yml
@@ -12,7 +12,7 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: true
 
 jobs:
   build_production:

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -7,7 +7,7 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -5,17 +5,16 @@ on: push
 env:
   RUBY_VERSION: 3.0.1
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   test:
     name: Installation and linting
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout Repository
         uses: actions/checkout@v3
 

--- a/.template/addons/github/.github/workflows/deploy_heroku.yml.tt
+++ b/.template/addons/github/.github/workflows/deploy_heroku.yml.tt
@@ -19,16 +19,15 @@ env:
   DOCKER_IMAGE: ${{ github.repository }}
   HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
-
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.workflow_run.head_branch || github.ref }}

--- a/.template/addons/github/.github/workflows/test.yml.tt
+++ b/.template/addons/github/.github/workflows/test.yml.tt
@@ -23,7 +23,7 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.template/addons/github/.github/workflows/test.yml.tt
+++ b/.template/addons/github/.github/workflows/test.yml.tt
@@ -21,16 +21,15 @@ env:
   # Set the default CI value despite the Github Action default value
   CI: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
     name: Build Docker image
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
-
       - uses: actions/checkout@v3
 
       - name: Set env BRANCH_TAG

--- a/.template/addons/github/.github/workflows/test_production_build.yml.tt
+++ b/.template/addons/github/.github/workflows/test_production_build.yml.tt
@@ -11,16 +11,15 @@ env:
   DOCKER_REGISTRY_HOST: ${{ secrets.DOCKER_REGISTRY_HOST }}
   DOCKER_IMAGE: ${{ github.repository }}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   docker_production_build_test:
     name: Build Docker production image
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
-
       - uses: actions/checkout@v3
 
       - name: Set env BRANCH_TAG

--- a/.template/addons/github/.github/workflows/test_production_build.yml.tt
+++ b/.template/addons/github/.github/workflows/test_production_build.yml.tt
@@ -13,7 +13,7 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: true
 
 jobs:
   docker_production_build_test:


### PR DESCRIPTION
- Close #378

## What happened 👀

- Remove `cancel-workflow-action` in all GitHub Actions workflows
- Use `concurrency` attributes in workflows to ensure only one job is run for each workflow 

## Insight 📝

We use `${{ github.workflow }}-${{ github.ref }}` for the group, which means separating it based on the `workflow` and the `ref`.

## Proof Of Work 📹

![image](https://user-images.githubusercontent.com/63148598/227176842-7abebc36-edb4-44df-bdf7-0837e1f1b711.png)