### PR TITLE
Do not override the ENV value on Docker build stage

### DIFF
--- a/bin/docker-assets-precompile
+++ b/bin/docker-assets-precompile
@@ -15,8 +15,8 @@ require 'yaml'
 rails_env = ENV.fetch('RAILS_ENV', 'production')
 
 if rails_env == 'production'
-  env_keys = YAML.load_file('config/application.yml')['docker_build'].keys
-  env_keys.each { |name| ENV[name] = 'dummy_value' }
+  docker_build_envs = YAML.load_file('config/application.yml')['docker_build']
+  docker_build_envs.each { |name, value| ENV[name] = value }
 
   ENV['DATABASE_URL'] = 'postgres://postgres:postgres@postgres:5432/postgres'
 end

--- a/config/application.yml.tt
+++ b/config/application.yml.tt
@@ -22,4 +22,4 @@ test:
 # Because it initializes the app, so all variables need to exist in the Docker build stage (used in bin/docker-assets-precompile).
 docker_build:
   <<: *default
-  SECRET_KEY_BASE:
+  SECRET_KEY_BASE: dummy_secret_key_base


### PR DESCRIPTION
## What happened 👀

Solve the bug on `export the I18n locale for Javascript`

## Insight 📝

- The I18n JS task needs the AVAILABLE_LOCALES information to translate all contents
- We do not override the value, instead we just use the original value from the `application.yml`

## Proof Of Work 📹

Tested on client projects
