### PR TITLE
[gh385] Minify the CSS and JS for production build

### DIFF
--- a/.template/spec/variants/web/package_json_spec.rb
+++ b/.template/spec/variants/web/package_json_spec.rb
@@ -29,6 +29,10 @@ describe 'Web variant - package.json' do
       expect(subject['scripts']).to include('build:css')
     end
 
+    it 'adds the script for bundling css in production' do
+      expect(subject['scripts']).to include('build:css-production')
+    end
+
     it 'adds the script for bundling postcss' do
       expect(subject['scripts']).to include('postcss')
       expect(subject['scripts']).to include('build:postcss')

--- a/.template/variants/web/Procfile.dev.rb
+++ b/.template/variants/web/Procfile.dev.rb
@@ -3,7 +3,7 @@
 append_to_file 'Procfile.dev' do
   <<~PROCFILE
     js: yarn build --watch
-    css: yarn build:css-dev --watch
+    css: yarn build:css --watch
     postcss: yarn build:postcss --watch
   PROCFILE
 end

--- a/.template/variants/web/Procfile.dev.rb
+++ b/.template/variants/web/Procfile.dev.rb
@@ -3,7 +3,7 @@
 append_to_file 'Procfile.dev' do
   <<~PROCFILE
     js: yarn build --watch
-    css: yarn build:css --watch
+    css: yarn build:css-dev --watch
     postcss: yarn build:postcss --watch
   PROCFILE
 end

--- a/.template/variants/web/app/javascript/build.js
+++ b/.template/variants/web/app/javascript/build.js
@@ -6,6 +6,7 @@ require('esbuild')
     inject: ['app/javascript/global.js'],
     bundle: true,
     sourcemap: true,
+    minify: !watch,
     outdir: 'app/assets/builds',
   })
   .then((ctx) => {

--- a/.template/variants/web/package.json.rb
+++ b/.template/variants/web/package.json.rb
@@ -41,22 +41,22 @@ run 'npm set-script codebase:fix "yarn eslint:fix && yarn stylelint:fix"'
 
 source_stylesheet = 'app/assets/stylesheets/application.scss'
 bundled_stylesheet = 'app/assets/builds/application.css'
-bundled_stylesheet_options = [
+bundled_stylesheet_base_options = [
   '--no-source-map',
   '--load-path=node_modules'
 ]
-production_bundled_stylesheet_options = [
+production_bundled_stylesheet_options = bundled_stylesheet_base_options + [
   '--style=compressed'
 ]
 
 run %(npm set-script build "node app/javascript/build.js")
 run %(
-  npm set-script build:css \
-  "sass #{source_stylesheet} #{bundled_stylesheet} #{(bundled_stylesheet_options + production_bundled_stylesheet_options).join(' ')}"
+  npm set-script build:css-production \
+  "sass #{source_stylesheet} #{bundled_stylesheet} #{(production_bundled_stylesheet_options).join(' ')}"
 )
 run %(
-  npm set-script build:css-dev \
-  "sass #{source_stylesheet} #{bundled_stylesheet} #{bundled_stylesheet_options.join(' ')}"
+  npm set-script build:css \
+  "sass #{source_stylesheet} #{bundled_stylesheet} #{bundled_stylesheet_base_options.join(' ')}"
 )
 run %(npm set-script postcss "postcss public/assets/*.css --dir public/assets --config ./")
 run %(

--- a/.template/variants/web/package.json.rb
+++ b/.template/variants/web/package.json.rb
@@ -52,7 +52,7 @@ production_bundled_stylesheet_options = [
 run %(npm set-script build "node app/javascript/build.js")
 run %(
   npm set-script build:css \
-  "sass #{source_stylesheet} #{bundled_stylesheet} #{bundled_stylesheet_options.merge(production_bundled_stylesheet_options).join(' ')}"
+  "sass #{source_stylesheet} #{bundled_stylesheet} #{(bundled_stylesheet_options + production_bundled_stylesheet_options).join(' ')}"
 )
 run %(
   npm set-script build:css-dev \

--- a/.template/variants/web/package.json.rb
+++ b/.template/variants/web/package.json.rb
@@ -45,10 +45,17 @@ bundled_stylesheet_options = [
   '--no-source-map',
   '--load-path=node_modules'
 ]
+production_bundled_stylesheet_options = [
+  '--style=compressed'
+]
 
 run %(npm set-script build "node app/javascript/build.js")
 run %(
   npm set-script build:css \
+  "sass #{source_stylesheet} #{bundled_stylesheet} #{bundled_stylesheet_options.merge(production_bundled_stylesheet_options).join(' ')}"
+)
+run %(
+  npm set-script build:css-dev \
   "sass #{source_stylesheet} #{bundled_stylesheet} #{bundled_stylesheet_options.join(' ')}"
 )
 run %(npm set-script postcss "postcss public/assets/*.css --dir public/assets --config ./")


### PR DESCRIPTION
close #385 

## What happened 👀

We customize the build process between development and `production`, as we want the `production` build to be as minimal as possible.

## Insight 📝

With JS, we config the `esbuild` configuration:
- Add `minify` option to be true in the case we don't have the `--watch` option (production)

With CSS, we separate two scripts:
- `build:css` for the production that included the `'--style=compressed'` option.
- `build:css-dev` for the `development` environment, without the compressed option.

## Proof Of Work 📹

| Minify JS                                                                                                                                                        	| Minify CSS                                                                                                                                                       	|
|------------------------------------------------------------------------------------------------------------------------------------------------------------------	|------------------------------------------------------------------------------------------------------------------------------------------------------------------	|
| <img width="801" alt="Screenshot 2023-05-05 at 10 46 04" src="https://github.com/nimblehq/rails-templates/assets/63148598/9114590b-2ef2-4004-bf7b-4f9a15780407"> 	| <img width="792" alt="Screenshot 2023-05-05 at 10 52 34" src="https://github.com/nimblehq/rails-templates/assets/63148598/55292910-9f10-4a6f-a040-3e03ca74258f"> 	|

Generated package.json

![image](https://github.com/nimblehq/rails-templates/assets/63148598/88c4abe6-5b81-40b2-a39b-099597a58e1b)

Generated Procfile.dev

![image](https://github.com/nimblehq/rails-templates/assets/63148598/658ae6af-02d4-4d78-a171-7645c8b3e41a)

