### PR TITLE
[#404] Fix: Loaderror: cannot load such file -- sassc when generating the project from the template

### DIFF
--- a/Gemfile.tt
+++ b/Gemfile.tt
@@ -9,6 +9,7 @@ gem 'mini_magick' # A ruby wrapper for ImageMagick or GraphicsMagick command lin
 gem 'pagy' # A pagination gem that is very light and fast
 gem 'discard' # Soft deletes for ActiveRecord
 gem 'sidekiq' # background processing for Ruby
+gem 'sassc' # bootsnap dependency
 gem 'bootsnap', require: false # Reduces boot times through caching; required in config/boot.rb
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby] # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 # gem 'jbuilder' # Build JSON APIs with ease


### PR DESCRIPTION
close #404 

## What happened 👀

We're currently failing to generate the project from our template, both API and Web. It might be caused by some dependencies added to the existing gems. 

## Insight 📝

- I tried to roll back to some old commits, but still faced the same errors -> the root cause not related to recent changes ❌ 
- I tried to add `gem 'sassc'` into the Gemfile (before `bootsnap`) -> it works ✅ 
- I tried to add `gem 'sassc'` after it (in the assets group) -> it works locally to generate the project BUT failed to run the CI ❌ 

## Proof Of Work 📹

Generate the project successfully locally.
![image](https://github.com/nimblehq/rails-templates/assets/63148598/cb41fd15-c999-4541-b60c-1ce084379e8a)
