### PR TITLE
[#383] Upgrade Node and Ruby dependency versions

### DIFF
--- a/.template/addons/bootstrap/package.json.rb
+++ b/.template/addons/bootstrap/package.json.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-run 'yarn add bootstrap@5.2.3'
+run 'yarn add bootstrap@5.3.0'
 run 'yarn add @popperjs/core@2.11.8'

--- a/.template/addons/bootstrap/package.json.rb
+++ b/.template/addons/bootstrap/package.json.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-run 'yarn add bootstrap@5.2.3'
-run 'yarn add @popperjs/core@2.11.2'
+run 'yarn add bootstrap@5.3.0'
+run 'yarn add @popperjs/core@2.11.8'

--- a/.template/addons/bootstrap/package.json.rb
+++ b/.template/addons/bootstrap/package.json.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-run 'yarn add bootstrap@5.3.0'
+run 'yarn add bootstrap@5.2.3'
 run 'yarn add @popperjs/core@2.11.8'

--- a/.template/addons/bootstrap/stylesheets/vendor/_bootstrap.scss
+++ b/.template/addons/bootstrap/stylesheets/vendor/_bootstrap.scss
@@ -6,6 +6,7 @@
 // Configuration
 @import 'bootstrap/scss/functions';
 @import 'bootstrap/scss/variables';
+@import 'bootstrap/scss/variables-dark';
 @import 'bootstrap/scss/maps';
 // @import 'sass_maps'; // Optional Sass map overrides here (See: https://getbootstrap.com/docs/5.2/migration/#new-_mapsscss)
 // e.g., $theme-colors: map-merge($theme-colors, $custom-theme-colors);

--- a/.template/addons/phrase/spec/codebase/codebase_spec.rb
+++ b/.template/addons/phrase/spec/codebase/codebase_spec.rb
@@ -5,7 +5,7 @@ insert_into_file 'spec/codebase/codebase_spec.rb', before: /end\Z/ do
 
     # rubocop:disable RSpec/ExampleLength
     it 'does not offend Phrase Pull configuration' do
-      locale_tags = Dir[File.expand_path(Rails.root.join('config', 'locales', '*.yml'))]
+      locale_tags = Dir[Rails.root.join('config', 'locales', '*.yml').expand_path]
                     .map { |path| path.split('/').last }
                     # ['campaign.en.yml', 'article.en.yml', 'campaign.th.yml', 'en.yml']
                     .map { |path| path.split('.').first }

--- a/.template/variants/web/app/javascript/global.js
+++ b/.template/variants/web/app/javascript/global.js
@@ -1,3 +1,3 @@
-import { I18n } from 'i18n-js';
+import I18n from 'i18n-js';
 
 export { I18n };

--- a/.template/variants/web/app/javascript/global.js
+++ b/.template/variants/web/app/javascript/global.js
@@ -1,3 +1,3 @@
-import I18n from 'i18n-js';
+import { I18n } from 'i18n-js';
 
 export { I18n };

--- a/.template/variants/web/package.json.rb
+++ b/.template/variants/web/package.json.rb
@@ -28,7 +28,7 @@ run 'yarn add sass'
 run 'yarn add esbuild'
 run 'yarn add postcss postcss-cli autoprefixer'
 
-run 'yarn add --dev @nimblehq/eslint-config-nimble@2.4.0'
+run 'yarn add --dev @nimblehq/eslint-config-nimble@2.2.1'
 run 'yarn add --dev stylelint'
 run 'yarn add --dev @nimblehq/stylelint-config-nimble@1.0.2'
 

--- a/.template/variants/web/package.json.rb
+++ b/.template/variants/web/package.json.rb
@@ -23,21 +23,22 @@ unless File.exist?('postcss.config.js')
 end
 
 # Install dependencies
-run 'yarn add i18n-js@3.8.0'
+run 'yarn add i18n-js@4.2.3'
 run 'yarn add sass'
 run 'yarn add esbuild'
 run 'yarn add postcss postcss-cli autoprefixer'
 
-run 'yarn add --dev @nimblehq/eslint-config-nimble@2.2.1'
+run 'yarn add --dev @nimblehq/eslint-config-nimble@2.6.0'
 run 'yarn add --dev stylelint'
-run 'yarn add --dev @nimblehq/stylelint-config-nimble'
+run 'yarn add --dev @nimblehq/stylelint-config-nimble@1.0.2'
+
 # Setup scripts
-run 'npm set-script eslint "eslint . --color"'
-run 'npm set-script eslint:fix "eslint . --color --fix"'
-run 'npm set-script stylelint "stylelint **/*.scss --color"'
-run 'npm set-script stylelint:fix "stylelint **/*.scss --color --fix"'
-run 'npm set-script codebase "yarn eslint && yarn stylelint"'
-run 'npm set-script codebase:fix "yarn eslint:fix && yarn stylelint:fix"'
+run 'npm pkg set scripts.eslint="eslint . --color"'
+run 'npm pkg set scripts.eslint:fix="eslint . --color --fix"'
+run 'npm pkg set scripts.stylelint="stylelint **/*.scss --color"'
+run 'npm pkg set scripts.stylelint:fix="stylelint **/*.scss --color --fix"'
+run 'npm pkg set scripts.codebase="yarn eslint && yarn stylelint"'
+run 'npm pkg set scripts.codebase:fix="yarn eslint:fix && yarn stylelint:fix"'
 
 source_stylesheet = 'app/assets/stylesheets/application.scss'
 bundled_stylesheet = 'app/assets/builds/application.css'
@@ -49,17 +50,18 @@ production_bundled_stylesheet_options = bundled_stylesheet_base_options + [
   '--style=compressed'
 ]
 
-run %(npm set-script build "node app/javascript/build.js")
+run %(npm pkg set scripts.build="node app/javascript/build.js")
 run %(
-  npm set-script build:css-production \
-  "sass #{source_stylesheet} #{bundled_stylesheet} #{production_bundled_stylesheet_options.join(' ')}"
+  npm pkg set scripts.build:css-production="sass\
+  #{source_stylesheet} #{bundled_stylesheet} #{production_bundled_stylesheet_options.join(' ')}"
 )
 run %(
-  npm set-script build:css \
-  "sass #{source_stylesheet} #{bundled_stylesheet} #{bundled_stylesheet_base_options.join(' ')}"
+  npm pkg set scripts.build:css="sass\
+  #{source_stylesheet} #{bundled_stylesheet} #{bundled_stylesheet_base_options.join(' ')}"
 )
-run %(npm set-script postcss "postcss public/assets/*.css --dir public/assets --config ./")
+run %(npm pkg set scripts.postcss="postcss\
+  public/assets/*.css --dir public/assets --config ./")
 run %(
-  npm set-script build:postcss \
-  "postcss app/assets/builds/*.css --dir app/assets/builds --config ./",
+  npm pkg set scripts.build:postcss="postcss\
+  app/assets/builds/*.css --dir app/assets/builds --config ./",
 )

--- a/.template/variants/web/package.json.rb
+++ b/.template/variants/web/package.json.rb
@@ -28,7 +28,7 @@ run 'yarn add sass'
 run 'yarn add esbuild'
 run 'yarn add postcss postcss-cli autoprefixer'
 
-run 'yarn add --dev @nimblehq/eslint-config-nimble@2.6.0'
+run 'yarn add --dev @nimblehq/eslint-config-nimble@2.4.0'
 run 'yarn add --dev stylelint'
 run 'yarn add --dev @nimblehq/stylelint-config-nimble@1.0.2'
 

--- a/.template/variants/web/package.json.rb
+++ b/.template/variants/web/package.json.rb
@@ -28,8 +28,9 @@ run 'yarn add sass'
 run 'yarn add esbuild'
 run 'yarn add postcss postcss-cli autoprefixer'
 
-run 'yarn add --dev @nimblehq/eslint-config-nimble@2.2.1'
+run 'yarn add --dev eslint'
 run 'yarn add --dev stylelint'
+run 'yarn add --dev @nimblehq/eslint-config-nimble@2.2.1'
 run 'yarn add --dev @nimblehq/stylelint-config-nimble@1.0.2'
 
 # Setup scripts

--- a/.template/variants/web/package.json.rb
+++ b/.template/variants/web/package.json.rb
@@ -23,7 +23,7 @@ unless File.exist?('postcss.config.js')
 end
 
 # Install dependencies
-run 'yarn add i18n-js@4.2.3'
+run 'yarn add i18n-js@3.8.0'
 run 'yarn add sass'
 run 'yarn add esbuild'
 run 'yarn add postcss postcss-cli autoprefixer'

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 16.13.2
+nodejs 16.20.1
 ruby 3.2.2

--- a/Gemfile.tt
+++ b/Gemfile.tt
@@ -21,7 +21,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby] # Windows doe
 gem 'pundit' # Minimal authorization through OO design and pure Ruby classes
 
 # Translations
-# gem 'rails-i18n', '~> 6.0.0' # Translations for Rails
+# gem 'rails-i18n', '~> 7.0' # Translations for Rails
 
 group :development do
   gem 'foreman' # Manage Procfile-based applications
@@ -31,7 +31,7 @@ group :development do
   gem 'roadie-rails' # Mailers
   gem 'spring' # Spring speeds up development by keeping your application running in the background.
   gem 'spring-commands-rspec' # This gem implements the rspec command for Spring.
-  gem 'spring-watcher-listen', '2.0.1' # Makes Spring watch the filesystem for changes using Listen
+  gem 'spring-watcher-listen', '2.1.0' # Makes Spring watch the filesystem for changes using Listen
 end
 
 group :development, :test do
@@ -53,7 +53,7 @@ group :development, :test do
   # Code Analysis
   gem 'bullet' # help to kill N+1 queries and unused eager loading
   gem 'brakeman', require: false # A static analysis security vulnerability scanner for Ruby on Rails applications
-  gem 'parser', '3.0.1.1' # Use correct parser version to avoid parser warnings
+  gem 'parser', '3.2.2.3' # Use correct parser version to avoid parser warnings
   gem 'rubocop', require: false # A Ruby static code analyzer and formatter, based on the community Ruby style guide.
   gem 'rubocop-rails', require: false # A RuboCop extension focused on enforcing Rails best practices and coding conventions.
   gem 'rubocop-rspec', require: false # Code style checking for RSpec files

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ with building complex applications over the years.
 
 - Install ruby and set your local ruby version to `3.2.2`
 - Install rails `7.0.6`
-- Install node `16.13.2` (For creating web application)
+- Install node `16.20.1` (For creating web application)
 
 > 📝 If running on Apple M1, to build docker image, please make sure to set platform to AMD64 by `export DOCKER_DEFAULT_PLATFORM=linux/amd64`
 

--- a/spec/codebase/codebase_spec.rb
+++ b/spec/codebase/codebase_spec.rb
@@ -16,7 +16,7 @@ describe 'Codebase', codebase: true do
   end
 
   it 'does not offend engine prefix name' do
-    engine_paths = Dir[File.expand_path(Rails.root.join('engines', '*'))]
+    engine_paths = Dir[Rails.root.join('engines', '*').expand_path]
                    .select { |f| File.directory? f }
                    .map { |path| path.split('/').last }
     invalid_engine_paths = engine_paths.reject { |path| path.start_with?('APP_NAME_HERE_') }

--- a/template.rb
+++ b/template.rb
@@ -21,7 +21,7 @@ DEFAULT_ADDONS = {
 }.freeze
 
 if WEB_VARIANT
-  NODE_VERSION = '16.13.2'
+  NODE_VERSION = '16.20.1'
   NODE_SOURCE_VERSION = '16' # Used in Dockerfile https://github.com/nodesource/distributions
 end
 


### PR DESCRIPTION
close #383

## What happened 👀

Upgrade Node and Ruby dependency versions

## Insight 📝

- Still stay as Node 16, there is a [new issue for Node 18](https://github.com/nimblehq/rails-templates/issues/421)
- I changed to use the new `npm pkg set` syntax over the `npm set-script` ([Slack message](https://nimble-co.slack.com/archives/C01GL6RBW11/p1688357829582519)) on this PR too

## Proof Of Work 📹

The CI is passed
