### PR TITLE
[#416] Remove sassc

### DIFF
--- a/Gemfile.tt
+++ b/Gemfile.tt
@@ -9,7 +9,6 @@ gem 'mini_magick' # A ruby wrapper for ImageMagick or GraphicsMagick command lin
 gem 'pagy' # A pagination gem that is very light and fast
 gem 'discard' # Soft deletes for ActiveRecord
 gem 'sidekiq' # background processing for Ruby
-gem 'sassc' # bootsnap dependency
 gem 'bootsnap', require: false # Reduces boot times through caching; required in config/boot.rb
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby] # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 # gem 'jbuilder' # Build JSON APIs with ease


### PR DESCRIPTION
close #416

## What happened 👀

Removed the sassc gem

## Insight 📝

I tried on local following the `Steps to reproduce` on https://github.com/nimblehq/rails-templates/issues/404 with

- Ruby 3.2.2
- Rails 7.0.6
- Without any addon

The project could be generated without any error

<img width="905" alt="image" src="https://github.com/nimblehq/rails-templates/assets/11751745/d989c2c7-1b3e-4efc-b1de-2279a82283e0">


## Proof Of Work 📹

No error on the `rails  importmap:install` or `rails  turbo:install stimulus:install` step

<img width="773" alt="image" src="https://github.com/nimblehq/rails-templates/assets/11751745/720f55a3-68be-4769-a2be-1c362d0fbb4a">

