### PR TITLE
Correct the build:css task

### DIFF
--- a/.template/spec/variants/web/package_json_spec.rb
+++ b/.template/spec/variants/web/package_json_spec.rb
@@ -26,11 +26,11 @@ describe 'Web variant - package.json' do
     end
 
     it 'adds the script for bundling css' do
-      expect(subject['scripts']).to include('build:css')
+      expect(subject['scripts']).to include('build:css-dev')
     end
 
     it 'adds the script for bundling css in production' do
-      expect(subject['scripts']).to include('build:css-production')
+      expect(subject['scripts']).to include('build:css')
     end
 
     it 'adds the script for bundling postcss' do

--- a/.template/variants/web/.gitignore.rb
+++ b/.template/variants/web/.gitignore.rb
@@ -26,5 +26,9 @@ append_to_file '.gitignore' do
 
     # Ignore Gemfile.lock file in engines.
     /engines/*/Gemfile.lock
+
+    # Ignore asset builds
+    /app/assets/builds/*
+    !/app/assets/builds/.keep
   IGNORE
 end

--- a/.template/variants/web/.gitignore.rb
+++ b/.template/variants/web/.gitignore.rb
@@ -26,9 +26,5 @@ append_to_file '.gitignore' do
 
     # Ignore Gemfile.lock file in engines.
     /engines/*/Gemfile.lock
-
-    # Ignore asset builds
-    /app/assets/builds/*
-    !/app/assets/builds/.keep
   IGNORE
 end

--- a/.template/variants/web/Procfile.dev.rb
+++ b/.template/variants/web/Procfile.dev.rb
@@ -3,7 +3,7 @@
 append_to_file 'Procfile.dev' do
   <<~PROCFILE
     js: yarn build --watch
-    css: yarn build:css --watch
+    css: yarn build:css-dev --watch
     postcss: yarn build:postcss --watch
   PROCFILE
 end

--- a/.template/variants/web/app/javascript/build.js
+++ b/.template/variants/web/app/javascript/build.js
@@ -2,7 +2,10 @@ const watch = process.argv.slice(2).includes('--watch');
 
 require('esbuild')
   .context({
-    entryPoints: ['app/javascript/application.js'],
+    entryPoints: [
+      { in: 'app/javascript/application.js', out: 'application.js' },
+      // { in: 'engines/[engine_name]/app/javascript/[engine_name]/application.js', out: '[engine_name]/application.js' },
+    ],
     inject: ['app/javascript/global.js'],
     bundle: true,
     sourcemap: true,

--- a/.template/variants/web/app/javascript/build.js
+++ b/.template/variants/web/app/javascript/build.js
@@ -3,8 +3,8 @@ const watch = process.argv.slice(2).includes('--watch');
 require('esbuild')
   .context({
     entryPoints: [
-      { in: 'app/javascript/application.js', out: 'application.js' },
-      // { in: 'engines/[engine_name]/app/javascript/[engine_name]/application.js', out: '[engine_name]/application.js' },
+      { in: 'app/javascript/application.js', out: 'application' },
+      // { in: 'engines/[engine_name]/app/javascript/[engine_name]/application.js', out: '[engine_name]/application' },
     ],
     inject: ['app/javascript/global.js'],
     bundle: true,

--- a/.template/variants/web/app/javascript/build.js
+++ b/.template/variants/web/app/javascript/build.js
@@ -11,6 +11,9 @@ require('esbuild')
     sourcemap: true,
     minify: !watch,
     outdir: 'app/assets/builds',
+    alias: {
+      'Core': './app/javascript/',
+    },
   })
   .then((ctx) => {
     watch ? ctx.watch() : ctx.rebuild().then(() => process.exit(0));

--- a/.template/variants/web/app/javascript/build.js
+++ b/.template/variants/web/app/javascript/build.js
@@ -11,9 +11,6 @@ require('esbuild')
     sourcemap: true,
     minify: !watch,
     outdir: 'app/assets/builds',
-    alias: {
-      'Core': './app/javascript/',
-    },
   })
   .then((ctx) => {
     watch ? ctx.watch() : ctx.rebuild().then(() => process.exit(0));

--- a/.template/variants/web/app/template.rb
+++ b/.template/variants/web/app/template.rb
@@ -21,7 +21,7 @@ remove_file 'app/assets/stylesheets/application.css'
 directory 'app/assets/stylesheets'
 directory 'app/assets/builds'
 
-run 'yarn build:css'
+run 'yarn build:css-dev'
 gsub_file 'app/assets/config/manifest.js', "//= link_directory ../stylesheets .css\n", ''
 append_to_file 'app/assets/config/manifest.js', '//= link_tree ../builds'
 

--- a/.template/variants/web/package.json.rb
+++ b/.template/variants/web/package.json.rb
@@ -53,12 +53,12 @@ production_bundled_stylesheet_options = bundled_stylesheet_base_options + [
 
 run %(npm pkg set scripts.build="node app/javascript/build.js")
 run %(
-  npm pkg set scripts.build:css-production="sass\
-  #{source_stylesheet} #{bundled_stylesheet} #{production_bundled_stylesheet_options.join(' ')}"
+  npm pkg set scripts.build:css-dev="sass\
+  #{source_stylesheet} #{bundled_stylesheet} #{bundled_stylesheet_base_options.join(' ')}"
 )
 run %(
   npm pkg set scripts.build:css="sass\
-  #{source_stylesheet} #{bundled_stylesheet} #{bundled_stylesheet_base_options.join(' ')}"
+  yarn build:css-dev #{production_bundled_stylesheet_options.join(' ')}"
 )
 run %(npm pkg set scripts.postcss="postcss\
   public/assets/*.css --dir public/assets --config ./")

--- a/.template/variants/web/package.json.rb
+++ b/.template/variants/web/package.json.rb
@@ -57,8 +57,7 @@ run %(
   #{source_stylesheet} #{bundled_stylesheet} #{bundled_stylesheet_base_options.join(' ')}"
 )
 run %(
-  npm pkg set scripts.build:css="sass\
-  yarn build:css-dev #{production_bundled_stylesheet_options.join(' ')}"
+  npm pkg set scripts.build:css="yarn build:css-dev #{production_bundled_stylesheet_options.join(' ')}"
 )
 run %(npm pkg set scripts.postcss="postcss\
   public/assets/*.css --dir public/assets --config ./")


### PR DESCRIPTION
## What happened 👀

Correct the `yarn task` for `build:css` as the `build:css-production` won't be trigger by any party, 

## Insight 📝

1. The [css-bundling](https://github.com/rails/cssbundling-rails/blob/main/lib/tasks/cssbundling/build.rake#L20) calls the `build:css` not `build:css-production` in the asset:precompile, see https://github.com/nimblehq/rails-templates/pull/405#discussion_r1251536103
2. For the `build:css-dev` we will use it in the `Procfile.dev`

## Proof Of Work 📹

The CI is passed
