### PR TITLE
[#223] Ignore Danger run on WIP pull request

### DIFF
--- a/.template/addons/github/.github/workflows/test.yml.tt
+++ b/.template/addons/github/.github/workflows/test.yml.tt
@@ -2,7 +2,6 @@ name: Test
 
 on:
   pull_request:
-    types: [opened, edited, labeled, unlabeled, converted_to_draft, ready_for_review]
   push:
     branches:
       - develop

--- a/.template/addons/github/.github/workflows/test.yml.tt
+++ b/.template/addons/github/.github/workflows/test.yml.tt
@@ -2,6 +2,7 @@ name: Test
 
 on:
   pull_request:
+    types: [opened, edited, labeled, unlabeled, converted_to_draft, ready_for_review]
   push:
     branches:
       - develop

--- a/.template/addons/github/.github/workflows/test.yml.tt
+++ b/.template/addons/github/.github/workflows/test.yml.tt
@@ -144,7 +144,7 @@ jobs:
     needs: unit_tests
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && !contains(join(github.event.pull_request.labels.*.name, ','), 'wip') && !contains(github.event.pull_request.title, '[wip]') && !github.event.pull_request.draft
     steps:
       - uses: actions/checkout@v3
         with:

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
 # Skip Danger run if the opened pull request has "wip" label, [WIP] in the title, or status is Draft
-has_wip_label = github.pr_labels.any? { |label| label.include? 'wip' }
-has_wip_title = github.pr_title.include? '[WIP]'
+has_wip_label = github.pr_labels.any? { |label| label.downcase.include? 'wip' }
+has_wip_title = github.pr_title.downcase.include? '[wip]'
 is_draft = github.pr_draft?
 
 if has_wip_label || has_wip_title || is_draft
-  message('Skipping Danger since PR is classed as Work in Progress')
-  return
+  return message('Skipping Danger since PR is classed as Work in Progress')
 end
 
 # Runs Rubocop and submit comments on modified and added files

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+# Skip Danger run if the opened pull request has "wip" label, [WIP] in the title, or status is Draft
+if github.pr_labels.include?('wip') || github.pr_title.include?('[WIP]') || github.pr_json['draft']
+  message('Skipping Danger run: Pull request is marked as work-in-progress or draft.')
+  return
+end
+
 # Runs Rubocop and submit comments on modified and added files
 rubocop.lint(inline_comment: true, force_exclusion: true)
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 # Skip Danger run if the opened pull request has "wip" label, [WIP] in the title, or status is Draft
-if github.pr_labels.include?('wip') || github.pr_title.include?('[WIP]') || github.pr_json['draft']
-  message('Skipping Danger run: Pull request is marked as work-in-progress or draft.')
+has_wip_label = github.pr_labels.any? { |label| label.include? 'wip' }
+has_wip_title = github.pr_title.include? '[WIP]'
+is_draft = github.pr_draft?
+
+if has_wip_label || has_wip_title || is_draft
+  message('Skipping Danger since PR is classed as Work in Progress')
   return
 end
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -6,7 +6,8 @@ has_wip_title = github.pr_title.downcase.include? '[wip]'
 is_draft = github.pr_draft?
 
 if has_wip_label || has_wip_title || is_draft
-  return message('Skipping Danger since PR is classed as Work in Progress')
+  message('Skipping Danger since PR is classed as Work in Progress')
+  return
 end
 
 # Runs Rubocop and submit comments on modified and added files

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,15 +1,5 @@
 # frozen_string_literal: true
 
-# Skip Danger run if the opened pull request has "wip" label, [WIP] in the title, or status is Draft
-has_wip_label = github.pr_labels.any? { |label| label.downcase.include? 'wip' }
-has_wip_title = github.pr_title.downcase.include? '[wip]'
-is_draft = github.pr_draft?
-
-if has_wip_label || has_wip_title || is_draft
-  message('Skipping Danger since PR is classed as Work in Progress')
-  return
-end
-
 # Runs Rubocop and submit comments on modified and added files
 rubocop.lint(inline_comment: true, force_exclusion: true)
 


### PR DESCRIPTION
close #223

## What happened 👀

- Skip danger run if PR has `[WIP]` in it's title
- Skip danger run if PR has `wip` in it's label
- Skip danger run if PR is in `draft`

## Insight 📝

- Tested on a project created from rails template. Worked successfully. 

## Proof Of Work 📹

<img width="1378" alt="Screen Shot 2023-07-05 at 3 08 43 PM" src="https://github.com/nimblehq/rails-templates/assets/12990839/35187153-9eca-4fb6-8fa6-665cb99f66b5">

