### PR TITLE
[#436] Fix invalid workflow bug for publish wiki workflow

### DIFF
--- a/.template/addons/github/.github/workflows/publish_wiki.yml.tt
+++ b/.template/addons/github/.github/workflows/publish_wiki.yml.tt
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
 

--- a/.template/addons/github/.github/workflows/publish_wiki.yml.tt
+++ b/.template/addons/github/.github/workflows/publish_wiki.yml.tt
@@ -7,9 +7,9 @@ on:
     paths:
       - .github/wiki/**
 
-env:
-  USER_NAME: github-wiki-workflow
-  USER_EMAIL: bot@nimblehq.co
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   publish:
@@ -18,11 +18,6 @@ jobs:
     timeout-minutes: 1
 
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.8.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout the repository
         uses: actions/checkout@v2
         with:
@@ -31,6 +26,6 @@ jobs:
       - name: Publish Github Wiki
         uses: nimblehq/publish-github-wiki-action@v1.0
         with:
-          user_name: ${{ env.USER_NAME }}
-          user_email: ${{ env.USER_EMAIL }}
+          user_name: github-wiki-workflow
+          user_email: bot@nimblehq.co
           user_access_token: ${{ secrets.USER_ACCESS_TOKEN }}

--- a/.template/addons/github/.github/workflows/publish_wiki.yml.tt
+++ b/.template/addons/github/.github/workflows/publish_wiki.yml.tt
@@ -2,18 +2,35 @@ name: Publish Wiki
 
 on:
   push:
-    paths:
-      - .github/wiki/**
     branches:
       - develop
+    paths:
+      - .github/wiki/**
+
 env:
-  USER_EMAIL: ${{ secrets.GH_EMAIL }}
+  USER_NAME: github-wiki-workflow
+  USER_EMAIL: bot@nimblehq.co
+
 jobs:
   publish:
-    name: Publish Wiki
-    uses: nimblehq/github-actions-workflows/.github/workflows/publish_wiki.yml@0.1.0
-    with:
-      USER_NAME: github-wiki-workflow
-      USER_EMAIL: $USER_EMAIL
-    secrets:
-      USER_TOKEN: ${{ secrets.GH_TOKEN }}
+    name: Publish Github Wiki
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+
+    steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Publish Github Wiki
+        uses: nimblehq/publish-github-wiki-action@v1.0
+        with:
+          user_name: ${{ env.USER_NAME }}
+          user_email: ${{ env.USER_EMAIL }}
+          user_access_token: ${{ secrets.USER_ACCESS_TOKEN }}

--- a/.template/addons/github/.github/workflows/publish_wiki.yml.tt
+++ b/.template/addons/github/.github/workflows/publish_wiki.yml.tt
@@ -6,13 +6,14 @@ on:
       - .github/wiki/**
     branches:
       - develop
-
+env:
+  USER_EMAIL: ${{ secrets.GH_EMAIL }}
 jobs:
   publish:
     name: Publish Wiki
     uses: nimblehq/github-actions-workflows/.github/workflows/publish_wiki.yml@0.1.0
     with:
       USER_NAME: github-wiki-workflow
-      USER_EMAIL: ${{ secrets.GH_EMAIL }}
+      USER_EMAIL: $USER_EMAIL
     secrets:
       USER_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
close #436

## What happened 👀

- Fix invalid workflow file bug for publish wiki workflow.


## Insight 📝

- `with` section wasn't getting access to `secrets` context.
```
    with:
      USER_NAME: github-wiki-workflow
      USER_EMAIL: ${{ secrets.GH_EMAIL }}
    secrets:
      USER_TOKEN: ${{ secrets.GH_TOKEN }}
```

- As suggested in this [RFC](https://github.com/nimblehq/compass/discussions/1019), used this new [action](https://github.com/nimblehq/publish-github-wiki-action) to handle wiki publish.

## Proof Of Work 📹

https://github.com/mosharaf13/rails-template-wiki/actions/runs/5485979793


<img width="848" alt="Screen Shot 2023-07-10 at 2 09 18 PM" src="https://github.com/nimblehq/rails-templates/assets/12990839/6a882a8c-0ad3-4675-9050-36f5b5042f2c">
