### PR TITLE
Enable source-map option in CSS build

### DIFF
--- a/.template/variants/web/package.json.rb
+++ b/.template/variants/web/package.json.rb
@@ -44,7 +44,7 @@ run 'npm pkg set scripts.codebase:fix="yarn eslint:fix && yarn stylelint:fix"'
 source_stylesheet = 'app/assets/stylesheets/application.scss'
 bundled_stylesheet = 'app/assets/builds/application.css'
 bundled_stylesheet_base_options = [
-  '--no-source-map',
+  '--source-map-urls=absolute',
   '--load-path=node_modules'
 ]
 production_bundled_stylesheet_options = bundled_stylesheet_base_options + [


### PR DESCRIPTION
close #414

## What happened 👀

- Enable source map when running css production build `yarn build:css`

## Insight 📝

- Generate source map with absolute path

## Proof Of Work 📹
![Screen Shot 2023-07-13 at 2 34 28 PM](https://github.com/nimblehq/rails-templates/assets/12990839/0eef029b-71ce-4c02-a8d5-5918e52f0436)

![Screen Shot 2023-07-13 at 2 34 57 PM](https://github.com/nimblehq/rails-templates/assets/12990839/7be89c32-d9fa-48bb-a638-e01c715a778b)
