### PR TITLE
[#448] Fix brakeman run raising error on CI.

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -4,7 +4,7 @@
 rubocop.lint(inline_comment: true, force_exclusion: true)
 
 # Runs Brakeman on modified and added files
-brakeman.run
+brakeman.run('./')
 
 # Runs Reek on modified and added files
 reek.lint


### PR DESCRIPTION
close #448 

## What happened 👀
Having the following error using `brakeman.run` in Dangerfile causing error on CI.
```
danger-brakeman_scanner-0.1.1/lib/danger_plugin.rb:18:in `dirname':  (Danger::DSLError)
[!] Invalid `Dangerfile` file: no implicit conversion of nil into String
 #  from Dangerfile:7
 #  -------------------------------------------
 #  # Runs Brakeman on modified and added files
 >  brakeman.run
 #  
```
```
/danger-brakeman_scanner-0.1.1/lib/danger_plugin.rb:18:in `dirname': no implicit conversion of nil into String (TypeError)

  def run(options = File.dirname(Kernel.caller_locations.first.absolute_path))
  ```

## Insight 📝

I try to run with `brakeman.run('.')` and `brakeman.run('/.')`. Both are working fine. 

## Proof Of Work 📹

This is the test repo using our template only with `brakeman.run`. The CI is failing with the brakeman error. 
Here's the [Action](https://github.com/htoo-eain-lwin/hello/actions/runs/5678135724/job/15387975631) and here's the [PR](https://github.com/htoo-eain-lwin/hello/pull/4) 

This is with `brakeman.run('./')`
Here's [Action](https://github.com/htoo-eain-lwin/hello/actions/runs/5678045077) and [PR](https://github.com/htoo-eain-lwin/hello/pull/3/files)