### PR TITLE
[#413] The test coverage does NOT show the correct statistics

### DIFF
--- a/.template/addons/github/.github/workflows/test.yml.tt
+++ b/.template/addons/github/.github/workflows/test.yml.tt
@@ -74,7 +74,7 @@ jobs:
         run: docker-compose pull test || true
 
       - name: Run codebase test
-        run: docker-compose run test bundle exec rspec spec/codebase/codebase_spec.rb --format progress
+        run: docker-compose run test -e DISABLE_SPRING=1 bundle exec rspec spec/codebase/codebase_spec.rb --format progress
 
   unit_tests:
     name: Unit tests
@@ -98,7 +98,7 @@ jobs:
         run: docker-compose pull test || true
 
       - name: Run unit tests
-        run: docker-compose run test bundle exec rspec --exclude-pattern "spec/systems/**/*_spec.rb, spec/codebase/codebase_spec.rb" --profile --format progress
+        run: docker-compose run test -e DISABLE_SPRING=1 bundle exec rspec --exclude-pattern "spec/systems/**/*_spec.rb, spec/codebase/codebase_spec.rb" --profile --format progress
 
       - name: Upload tests coverage artifact
         uses: actions/upload-artifact@v3

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+require 'spec_helper'
+require 'support/simplecov'
+
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 
-require 'spec_helper'
 require 'rspec/rails'
 require 'json_matchers/rspec'
 require 'pundit/rspec'


### PR DESCRIPTION
close #413 

## What happened 👀

Resolved the issue related to the code coverage always showing 0.00%, which means it does not reflect the real code coverage of the project. 

## Insight 📝

It was caused by the SimpleCov not starting before the Rails was loaded.

## Proof Of Work 📹

Tested and worked well on [the public repo](https://github.com/sanG-github/test-code-coverage/pull/1#issuecomment-1660059827)

<img width="886" alt="Screenshot 2023-08-01 at 17 57 12" src="https://github.com/nimblehq/rails-templates/assets/63148598/b984611c-1c09-47b8-b6f3-c75c50aff0d4">
