### PR TITLE
[#447] Remove unexpected_input being passed to actions/download-artifact@v3

### DIFF
--- a/.template/addons/github/.github/workflows/test.yml.tt
+++ b/.template/addons/github/.github/workflows/test.yml.tt
@@ -153,9 +153,6 @@ jobs:
       - name: Download tests coverage artifact
         uses: actions/download-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: test.yml
-          workflow_conclusion: success
           name: coverage
           path: coverage
 


### PR DESCRIPTION
close #447 

## What happened 👀

We're providing some additional inputs that do not expect by the `download-artifact@v3` action.

## Insight 📝

Just removed the redundant inputs: `github_token, workflow, workflow_conclusion` as described. Keeps only the `name, path` inputs.

![image](https://github.com/nimblehq/rails-templates/assets/63148598/9148c2e1-8cf7-40af-b8c3-c938c4936a1c)


## Proof Of Work 📹

`n/a`
