### PR TITLE
[#417] Revise the config to generate the project for `--api` accordingly

### DIFF
--- a/.template/addons/github/.github/workflows/deploy_heroku.yml.tt
+++ b/.template/addons/github/.github/workflows/deploy_heroku.yml.tt
@@ -5,9 +5,8 @@ on:
     workflows:
       - Test
     branches:
-      - master
       - main
-      - development
+      - develop
     types:
       - completed
   workflow_dispatch:

--- a/.template/addons/github/.github/workflows/test.yml.tt
+++ b/.template/addons/github/.github/workflows/test.yml.tt
@@ -13,7 +13,9 @@ env:
   DOCKER_REGISTRY_USERNAME: ${{ github.repository_owner }}
   DOCKER_REGISTRY_TOKEN: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
   DOCKER_IMAGE: ${{ github.repository }}
+  <%- if WEB_VARIANT -%>
   NODE_VERSION: 16
+  <%- end -%>
 
   # Set the default docker-compose file
   COMPOSE_FILE: docker-compose.test.yml
@@ -106,6 +108,7 @@ jobs:
           name: coverage
           path: coverage
 
+  <%- if WEB_VARIANT -%>
   system_tests:
     name: System tests
     runs-on: ubuntu-latest
@@ -139,6 +142,7 @@ jobs:
           name: system_tests_screenshots
           path: tmp/screenshots/
 
+  <%- end -%>
   automated_code_review:
     name: Run Danger
     needs: unit_tests
@@ -161,6 +165,7 @@ jobs:
         with:
           bundler-cache: true
 
+      <%- if WEB_VARIANT -%>
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
@@ -180,6 +185,7 @@ jobs:
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: yarn
 
+      <%- end -%>
       - name: Run Undercover
         run: bundle exec undercover-report
 

--- a/.template/addons/github/.github/workflows/test_production_build.yml.tt
+++ b/.template/addons/github/.github/workflows/test_production_build.yml.tt
@@ -3,9 +3,8 @@ name: Test production build
 on:
   push:
     branches-ignore:
-      - master
       - main
-      - development
+      - develop
 
 env:
   DOCKER_REGISTRY_HOST: ${{ secrets.DOCKER_REGISTRY_HOST }}

--- a/.template/hooks/before_complete/fix_rubocop.rb
+++ b/.template/hooks/before_complete/fix_rubocop.rb
@@ -10,7 +10,7 @@ def fixing_rubocop
       Layout/EmptyLineAfterMagicComment
     ].join(',')
 
-    run "rubocop --only #{cops} --auto-correct-all --out tmp/template_rubocop.txt"
+    run "rubocop --only #{cops} --autocorrect-all --out tmp/template_rubocop.txt"
   end
 end
 

--- a/.template/spec/base/bin/template_spec.rb
+++ b/.template/spec/base/bin/template_spec.rb
@@ -25,9 +25,4 @@ describe '/bin template' do
     expect(file('bin/docker-prepare')).to exist
     expect(file('bin/docker-prepare')).to be_executable
   end
-
-  it 'creates the docker asset precompile script' do
-    expect(file('bin/docker-assets-precompile')).to exist
-    expect(file('bin/docker-assets-precompile')).to be_executable
-  end
 end

--- a/.template/spec/variants/web/template_spec.rb
+++ b/.template/spec/variants/web/template_spec.rb
@@ -24,4 +24,9 @@ describe 'Web variant - template' do
     expect(file('app/assets/config/manifest.js')).not_to contain('//= link_directory ../stylesheets .css')
     expect(file('app/assets/config/manifest.js')).to contain('//= link_tree ../builds')
   end
+
+  it 'creates the docker asset precompile script' do
+    expect(file('bin/docker-assets-precompile')).to exist
+    expect(file('bin/docker-assets-precompile')).to be_executable
+  end
 end

--- a/Makefile.tt
+++ b/Makefile.tt
@@ -14,6 +14,7 @@ env/setup:
 env/teardown:  # this command will delete data
 	./bin/envteardown.sh
 
+<%- if WEB_VARIANT -%>
 install-dependencies:
 	bundle install
 	yarn install
@@ -25,3 +26,13 @@ codebase:
 codebase/fix:
 	rubocop -a
 	yarn codebase:fix
+<%- else -%>
+install-dependencies:
+	bundle install
+
+codebase:
+	rubocop
+
+codebase/fix:
+	rubocop -a
+<%- end -%>

--- a/bin/template.rb
+++ b/bin/template.rb
@@ -6,7 +6,4 @@ copy_file 'bin/start.sh', mode: :preserve
 copy_file 'bin/test.sh', mode: :preserve
 copy_file 'bin/worker.sh', mode: :preserve
 copy_file 'bin/docker-prepare', mode: :preserve
-
-if WEB_VARIANT
-copy_file 'bin/docker-assets-precompile', mode: :preserve
-end
+copy_file 'bin/docker-assets-precompile', mode: :preserve if WEB_VARIANT

--- a/bin/template.rb
+++ b/bin/template.rb
@@ -6,4 +6,7 @@ copy_file 'bin/start.sh', mode: :preserve
 copy_file 'bin/test.sh', mode: :preserve
 copy_file 'bin/worker.sh', mode: :preserve
 copy_file 'bin/docker-prepare', mode: :preserve
+
+if WEB_VARIANT
 copy_file 'bin/docker-assets-precompile', mode: :preserve
+end

--- a/config/application.yml.tt
+++ b/config/application.yml.tt
@@ -18,8 +18,13 @@ test:
   <<: *default
   TEST_RETRY: "0"
 
+<%- if WEB_VARIANT -%>
 # Set environment variables required in the initializers in order to precompile the assets.
 # Because it initializes the app, so all variables need to exist in the Docker build stage (used in bin/docker-assets-precompile).
 docker_build:
   <<: *default
   SECRET_KEY_BASE: dummy_secret_key_base
+<%- else -%>
+docker_build:
+  <<: *default
+<%- end -%>


### PR DESCRIPTION
close #417

## What happened 👀

Improve the project generated by the template with the `--api` option, which is API application only. 

> [!NOTE]
> Due to the need for OpenAPI specs from `node` later, we no longer need to remove it.

## Insight 📝

- Removed all redundant parts as mentioned in the issue, thanks to @hoangnguyen92dn.
- Also change the deprecated `option` when running rubocop.

## Proof Of Work 📹

| Option before                                                                                                                          	| Option after                                                                                                                           	|
|----------------------------------------------------------------------------------------------------------------------------------------	|----------------------------------------------------------------------------------------------------------------------------------------	|
| ![Screenshot 2023-08-04 at 14 29 53](https://github.com/nimblehq/rails-templates/assets/63148598/8192bae3-fc7f-4501-8cae-61627e5fe98a) 	| ![Screenshot 2023-08-04 at 14 32 55](https://github.com/nimblehq/rails-templates/assets/63148598/d0e34463-df9b-4a36-866a-0860cce925b4) 	|
