### PR TITLE
[#456] Fix setting Chrome's locale to non-English will cause some Capybara tests to fail

### DIFF
--- a/.template/variants/web/spec/support/capybara.rb
+++ b/.template/variants/web/spec/support/capybara.rb
@@ -28,6 +28,9 @@ Capybara.register_driver(:headless_chrome) do |app|
   # Disable /dev/shm use in CI
   options.add_argument('disable-dev-shm-usage') if ENV['CI']
 
+  # Use English locale for displaying page
+  options.add_preference('intl.accept_languages', 'en')
+
   Capybara::Selenium::Driver.new(
     app,
     browser: :chrome,


### PR DESCRIPTION
close #456 

## What happened 👀

Capybara tries to run the UI tests on different locale than our test suite causing a problem looking up some elements which contain localized string.

## Insight 📝

- Capybara should not inherit the page locale from the local web browser locale and instead always use English.

## Proof Of Work 📹

All tests passed.
