### PR TITLE
Update the sidekiq queue config

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,3 +3,7 @@
 :queues:
   - [default, 1]
   - [mailers, 2]
+  - [development_default, 1]
+  - [development_mailers, 2]
+  - [production_default, 1]
+  - [production_mailers, 2]

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,8 +1,6 @@
 ---
 :concurrency: <%= ENV['SIDEKIQ_CONCURRENCY'] || 4 %>
 :queues:
-  - [default, 1]
-  - [mailers, 2]
   - [development_default, 1]
   - [development_mailers, 2]
   - [production_default, 1]


### PR DESCRIPTION
## What happened 👀

Add the queues with Rails env prefix in order to allow the Sidekiq job get processed.

## Insight 📝

The new default Rails generate had the `config.active_job.queue_name_prefix = Rails.env` which will require the Sidekiq queue to include these env prefixes.

## Proof Of Work 📹

Used in client projects
