### PR TITLE
[#459] Remove schema.rb from .gitattributes linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# See https://git-scm.com/docs/gitattributes for more about git attribute files.
+
+# Mark any vendored files as having been vendored.
+vendor/* linguist-vendored

--- a/.template/spec/base/template_spec.rb
+++ b/.template/spec/base/template_spec.rb
@@ -30,4 +30,9 @@ describe 'Base template' do
   it 'creates Reek configuration files' do
     expect(file('.reek.yml')).to exist
   end
+
+  it 'creates the .gitattributes without schema.db' do
+    expect(file('.gitattributes')).to exist
+    expect(file('.gitattributes')).not_to contain('db/schema.rb')
+  end
 end

--- a/template.rb
+++ b/template.rb
@@ -49,6 +49,7 @@ def apply_template!(template_root)
   apply 'bin/template.rb'
   apply 'config/template.rb'
   apply '.gitignore.rb'
+  copy_file '.gitattributes', force: true
 
   after_bundle do
     use_source_path template_root


### PR DESCRIPTION
close #459

## What happened 👀

- Remove db/schema.rb from the git attributes auto-hidden files
- Add a test as well

## Insight 📝

`n/a`

## Proof Of Work 📹

After generating a new app named `man` (for `manger` in French, meaning `to eat` 🤡):

<img width="906" alt="image" src="https://github.com/nimblehq/rails-templates/assets/77609814/983c7bf3-68ec-4bf1-bafd-2a83d76bc8f1">

