### PR TITLE
[#470][Pending experimentation] Add Jest to test javascript and Stimulus controllers

### DIFF
--- a/.template/addons/hotwire/.eslintrc.rb
+++ b/.template/addons/hotwire/.eslintrc.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+insert_into_file('.eslintrc', before: "\n  \"extends\"") do
+  <<~ESLINTRC
+
+    "env": {
+      "jest": true
+    },
+  ESLINTRC
+end

--- a/.template/addons/hotwire/package.json.rb
+++ b/.template/addons/hotwire/package.json.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Install dependencies
+run 'yarn add --dev jest'
+run 'yarn add --dev jest-environment-jsdom'
+run 'yarn add --dev esbuild-jest'
+
+# Jest config
+run 'npm pkg set jest.testRegex[]="spec/javascript/.*_spec\\.js"'
+run %(npm pkg set jest.transform='{"^.+\\\\.js?$": "esbuild-jest"}' -json)
+run 'npm pkg set jest.testEnvironment="jsdom"'
+run 'npm pkg set jest.roots[]="spec/javascript"'
+run 'npm pkg set jest.moduleDirectories[]="node_modules"'

--- a/.template/addons/hotwire/spec/javascript/controllers/hello_controller_spec.js
+++ b/.template/addons/hotwire/spec/javascript/controllers/hello_controller_spec.js
@@ -1,0 +1,20 @@
+import { Application } from '@hotwired/stimulus';
+
+import HelloController from '../../../app/javascript/controllers/hello_controller';
+
+describe('HelloConttroller', () => {
+  describe('#greet', () => {
+    beforeEach(() => {
+      document.body.innerHTML = `<div id="element" data-controller="hello"></div>`;
+
+      const application = Application.start();
+      application.register('hello', HelloController);
+    });
+
+    it('displays hello world into the main element', () => {
+      const element = document.getElementById('element');
+
+      expect(element.textContent).toEqual('Hello World!');
+    });
+  });
+});

--- a/.template/addons/hotwire/template.rb
+++ b/.template/addons/hotwire/template.rb
@@ -1,3 +1,8 @@
 # frozen_string_literal: true
 
 apply '.template/addons/hotwire/Gemfile.rb'
+apply '.template/addons/hotwire/package.json.rb'
+apply '.template/addons/hotwire/.eslintrc.rb'
+
+directory '.template/addons/hotwire/spec/javascript/controllers',
+          'spec/javascript/controllers'

--- a/.template/spec/addons/variants/web/hotwire/eslintrc_spec.rb
+++ b/.template/spec/addons/variants/web/hotwire/eslintrc_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+describe 'Hotwire Addon - eslintrc' do
+  it 'adds the env "jest" to the eslint configuration' do
+    eslintrc = JSON.parse(file('.eslintrc').content)
+
+    expect(eslintrc['env']).to include('jest')
+  end
+end

--- a/.template/spec/addons/variants/web/hotwire/package_json_spec.rb
+++ b/.template/spec/addons/variants/web/hotwire/package_json_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+describe 'Hotwire Addon - package.json' do
+  subject do
+    JSON.parse(file('package.json').content)
+  end
+
+  describe 'Jest Config' do
+    it 'adds the jest config' do
+      expect(subject['jest']).to include('testRegex')
+      expect(subject['jest']).to include('transform')
+      expect(subject['jest']).to include('testEnvironment')
+      expect(subject['jest']).to include('roots')
+      expect(subject['jest']).to include('moduleDirectories')
+    end
+  end
+
+  describe 'Development Dependencies' do
+    it 'adds the jest dependencies' do
+      expect(subject['devDependencies']).to include('jest')
+      expect(subject['devDependencies']).to include('jest-environment-jsdom')
+    end
+
+    it 'adds the esbuild-jest dependency' do
+      expect(subject['devDependencies']).to include('esbuild-jest')
+    end
+  end
+end

--- a/.template/spec/addons/variants/web/hotwire/template_spec.rb
+++ b/.template/spec/addons/variants/web/hotwire/template_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+describe 'Hotwire Addon - template' do
+  it 'creates the specs for the HelloWorld stimulus controller' do
+    expect(file('spec/javascript/controllers/hello_controller_spec.js')).to exist
+  end
+end


### PR DESCRIPTION
close #470

## What happened 👀

- [x] Add Jest config compatible with Stimulus controllers
- [x] Add the hello world controller with its tests
- [x] Add the template tests 

## Insight 📝

This PR does NOT configure Jest for the Web variant without Hotwire, as I assume the reason to NOT choose hotwire is to use a different JS framework which will probably need a slightly different configuration/tests.

> [!NOTE]
> The GitHub workflow to run Jest in CI will be added in another PR attached to #472

## Proof Of Work 📹

Tests are passing, right after the app was created ✨🚀✨ 

<img width="519" alt="image" src="https://github.com/nimblehq/rails-templates/assets/77609814/03ea8f3c-2857-4ec0-af91-e13095a60846">

### Files:

|.eslintrc|package.json|
|---|---|
|![image](https://github.com/nimblehq/rails-templates/assets/77609814/896f1b8d-fc3f-410b-b26b-45c6c701e96d)|![image](https://github.com/nimblehq/rails-templates/assets/77609814/b5a4dc17-f77f-4d3c-838f-95f94dd41972)|


### `package.json` jest config:

```
  "jest": {
    "testRegex": [
      "spec/javascript/.*_spec\\.js"
    ],
    "transform": {
      "^.+\\.js?$": "esbuild-jest"
    },
    "testEnvironment": "jsdom",
    "roots": [
      "spec/javascript"
    ],
    "moduleDirectories": [
      "node_modules"
    ]
  }
```
