### PR TITLE
Update README regarding copying the .env file

### DIFF
--- a/.template/variants/web/.gitignore.rb
+++ b/.template/variants/web/.gitignore.rb
@@ -26,5 +26,8 @@ append_to_file '.gitignore' do
 
     # Ignore Gemfile.lock file in engines.
     /engines/*/Gemfile.lock
+
+    # Ignore env file
+    .env
   IGNORE
 end

--- a/README.md.tt
+++ b/README.md.tt
@@ -19,11 +19,17 @@
 
 ### Development
 
+Copy the contents of `.env.example` to `.env`
+
+```sh
+cp .env.example .env
+```
+
 Run the Rails app:
 
 ```sh
 make dev
-``
+```
 
 ## Testing
 


### PR DESCRIPTION
## What happened 👀

After initializing a new project using the template, we need to copy the `.env.example` to `.env`. This enables the `Makefile` to work without any errors.

## Insight 📝

N/A

## Proof Of Work 📹

File changes