### PR TITLE
[#478] Fix: Duplicated `Dockerfile` and `.dockerignore` when generating the project with Rails 7.1

### DIFF
--- a/.template/addons/docker/template.rb
+++ b/.template/addons/docker/template.rb
@@ -2,6 +2,9 @@
 
 use_source_path __dir__
 
+remove_file 'Dockerfile'
+remove_file '.dockerignore'
+
 template 'Dockerfile.tt'
 template 'docker-compose.dev.yml.tt'
 template 'docker-compose.test.yml.tt'


### PR DESCRIPTION
close #478

## What happened 👀

Just remove the files before applying the Docker template. Later we might want to reverse that if we choose to use the default Rails docker files 👍 

## Insight 📝

`n/a`

## Proof Of Work 📹

<img width="788" alt="image" src="https://github.com/nimblehq/rails-templates/assets/77609814/554ba987-f762-41ea-b26f-f8638e4db127">

