### PR TITLE
[#489] Fix: Postcss not compatible with Node 16

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -7,11 +7,11 @@ labels: "type : bug"
 
 ## Issue
 
-Describe the issue you are facing. Show us the implementation: screenshots, gif, etc.
+Describe the issue you are facing. Show us the implementation: screenshots, GIFs, etc.
 
 ## Expected
 
-Describe what should be the correct behaviour.
+Describe what should be the correct behavior.
 
 ## Steps to reproduce
 

--- a/.github/ISSUE_TEMPLATE/chore_template.md
+++ b/.github/ISSUE_TEMPLATE/chore_template.md
@@ -1,0 +1,14 @@
+---
+name: "Chore"
+about: "Open a chore issue for a minor update."
+title: "Update "
+labels: "type : chore"
+---
+
+## Why
+
+Describe the update in detail and why it is needed.
+
+## Who Benefits?
+
+Describe who will be the beneficiaries e.g. everyone, specific chapters, clients...

--- a/.github/ISSUE_TEMPLATE/feature_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_template.md
@@ -7,7 +7,7 @@ labels: "type : feature"
 
 ## Why
 
-Describe the big picture of the feature and why it's needed.
+Describe the big picture of the feature and why it is needed.
 
 ## Who Benefits?
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-close #
+- Close #
 
 ## What happened 👀
 

--- a/.github/PULL_REQUEST_TEMPLATE/release_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_template.md
@@ -1,0 +1,15 @@
+[{RELEASE_TAG}](https://github.com/nimblehq/rails-templates/milestone/{MILESTONE_ID}?closed=1)
+
+## Features
+
+Provide the ID and title of the issue in the section for each type (feature, chore and bug). The link is optional.
+
+- [#1234] As a user, I can log in
+
+## Chores
+
+- Same structure as in  ## Feature
+
+## Bugs
+
+- Same structure as in  ## Feature

--- a/.github/workflows/test_generated_app.yml
+++ b/.github/workflows/test_generated_app.yml
@@ -10,8 +10,8 @@ env:
   DOCKER_REGISTRY_USERNAME: ${{ github.repository_owner }}
   DOCKER_REGISTRY_TOKEN: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
   RUBY_VERSION: 3.2.2
-  NODE_VERSION: 16
-  RAILS_VERSION: 7.0.6
+  NODE_VERSION: 18
+  RAILS_VERSION: 7.1.2
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test_production_build.yml
+++ b/.github/workflows/test_production_build.yml
@@ -7,8 +7,8 @@ env:
   DOCKER_IMAGE: ${{ github.repository }}
   DOCKER_REGISTRY_HOST: ${{ secrets.DOCKER_REGISTRY_HOST }}
   RUBY_VERSION: 3.2.2
-  NODE_VERSION: 16
-  RAILS_VERSION: 7.0.6
+  NODE_VERSION: 18
+  RAILS_VERSION: 7.1.2
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.template/addons/github/.github/workflows/test.yml.tt
+++ b/.template/addons/github/.github/workflows/test.yml.tt
@@ -14,7 +14,7 @@ env:
   DOCKER_REGISTRY_TOKEN: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
   DOCKER_IMAGE: ${{ github.repository }}
   <%- if WEB_VARIANT -%>
-  NODE_VERSION: 16
+  NODE_VERSION: 18
   <%- end -%>
 
   # Set the default docker-compose file

--- a/.template/variants/web/.stylelintrc
+++ b/.template/variants/web/.stylelintrc
@@ -3,7 +3,6 @@
     "@nimblehq/stylelint-config-nimble"
   ],
   "rules": {
-    "no-eol-whitespace": true,
     "max-nesting-depth": 3,
     "scss/at-extend-no-missing-placeholder": null,
     "order/properties-alphabetical-order": null

--- a/.template/variants/web/app/assets/stylesheets/functions/_sizing.scss
+++ b/.template/variants/web/app/assets/stylesheets/functions/_sizing.scss
@@ -1,12 +1,14 @@
+@use 'sass:list';
+
 @function em($values, $base-font-size: 16px) {
   $list: ();
 
   @each $value in $values {
     @if ($value == 0 or $value == auto) {
-      $list: append($list, $value);
+      $list: list.append($list, $value);
     } @else {
       $em-value: calc($value / $base-font-size) + em;
-      $list: append($list, $em-value);
+      $list: list.append($list, $em-value);
     }
   }
 
@@ -18,10 +20,10 @@
 
   @each $value in $values {
     @if ($value == 0 or $value == auto) {
-      $list: append($list, $value);
+      $list: list.append($list, $value);
     } @else {
       $rem-value: calc($value / $base-font-size) + rem;
-      $list: append($list, $rem-value);
+      $list: list.append($list, $rem-value);
     }
   }
 

--- a/.template/variants/web/package.json.rb
+++ b/.template/variants/web/package.json.rb
@@ -31,7 +31,7 @@ run 'yarn add postcss postcss-cli autoprefixer'
 run 'yarn add --dev eslint'
 run 'yarn add --dev stylelint'
 run 'yarn add --dev @nimblehq/eslint-config-nimble@2.2.1'
-run 'yarn add --dev @nimblehq/stylelint-config-nimble@1.0.2'
+run 'yarn add --dev @nimblehq/stylelint-config-nimble@1.1.0'
 
 # Setup scripts
 run 'npm pkg set scripts.eslint="eslint . --color"'

--- a/.template/variants/web/package.json.rb
+++ b/.template/variants/web/package.json.rb
@@ -29,7 +29,7 @@ run 'yarn add esbuild'
 run 'yarn add postcss postcss-cli autoprefixer'
 
 run 'yarn add --dev eslint'
-run 'yarn add --dev stylelint'
+run 'yarn add --dev stylelint@^15'
 run 'yarn add --dev @nimblehq/eslint-config-nimble@2.2.1'
 run 'yarn add --dev @nimblehq/stylelint-config-nimble@1.1.0'
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 16.20.1
+nodejs >= 18
 ruby 3.2.2

--- a/Gemfile.tt
+++ b/Gemfile.tt
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 ruby '<%= RUBY_VERSION %>'
 
 # Backend
-gem 'rails', '7.0.6' # Latest stable
+gem 'rails', '7.1.2' # Latest stable
 gem 'pg' # Use Postgresql as database
 gem 'puma' # Use Puma as the app server
 gem 'mini_magick' # A ruby wrapper for ImageMagick or GraphicsMagick command line

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ with building complex applications over the years.
 ### Requirements
 
 - Install ruby and set your local ruby version to `3.2.2`
-- Install rails `7.0.6`
-- Install node `16.20.1` (For creating web application)
+- Install rails `7.1.2`
+- Install node `18.19.0` (For creating web application)
 
 > 📝 If running on Apple M1, to build docker image, please make sure to set platform to AMD64 by `export DOCKER_DEFAULT_PLATFORM=linux/amd64`
 

--- a/template.rb
+++ b/template.rb
@@ -21,8 +21,8 @@ DEFAULT_ADDONS = {
 }.freeze
 
 if WEB_VARIANT
-  NODE_VERSION = '16.20.1'
-  NODE_SOURCE_VERSION = '16' # Used in Dockerfile https://github.com/nodesource/distributions
+  NODE_VERSION = '18.19.0'
+  NODE_SOURCE_VERSION = '18' # Used in Dockerfile https://github.com/nodesource/distributions
 end
 
 def apply_template!(template_root)


### PR DESCRIPTION
close #489

## What happened 👀

It's faster to just update the needed dependencies rather than locking the template with outdated dependencies (with the cascading effect this can have).

## Insight 📝

- Rails 7.1.2
- Node 18.19
- Nimble Stylelint config 1.1.0 (required to lock `stylelint` to version 15 // version 16 raise an error)

Stylelint also came with new errors and I had to remove the global functions calls in favor of namespaced one.

## Proof Of Work 📹

The tests should now pass. No behavior changed. :white_check_mark: 
