### PR TITLE
[#494] Create (or use) a Rubocop for the inverse keyword needed in the associations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ require:
   - rubocop-rails
   - rubocop-rspec
   - rubocop-performance
+  - ./lib/custom_cops/required_inverse_of_relations.rb
 
 AllCops:
   Exclude:
@@ -50,3 +51,6 @@ RSpec/NestedGroups:
 
 RSpec/MultipleExpectations:
   Max: 10
+
+CustomCops/RequiredInverseOfRelations:
+  Enabled: true

--- a/.template/addons/custom_cops/template.rb
+++ b/.template/addons/custom_cops/template.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+
+FileUtils.mkdir_p 'lib/custom_cops'
+copy_file 'custom_cops/required_inverse_of_relations.rb', 'lib/custom_cops/required_inverse_of_relations.rb'

--- a/custom_cops/Gemfile
+++ b/custom_cops/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'rubocop'
+gem 'rspec'

--- a/custom_cops/Gemfile.lock
+++ b/custom_cops/Gemfile.lock
@@ -1,0 +1,53 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    diff-lcs (1.5.0)
+    json (2.7.1)
+    language_server-protocol (3.17.0.3)
+    parallel (1.24.0)
+    parser (3.2.2.4)
+      ast (~> 2.4.1)
+      racc
+    racc (1.7.3)
+    rainbow (3.1.1)
+    regexp_parser (2.8.3)
+    rexml (3.2.6)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.6)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.1)
+    rubocop (1.59.0)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.2.2.4)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (2.5.0)
+
+PLATFORMS
+  arm64-darwin-22
+
+DEPENDENCIES
+  rspec
+  rubocop
+
+BUNDLED WITH
+   2.4.17

--- a/custom_cops/required_inverse_of_relations.rb
+++ b/custom_cops/required_inverse_of_relations.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module CustomCops
+  class RequiredInverseOfRelations < RuboCop::Cop::Base
+    MSG = 'Use inverse_of option when defining associations to prevent avoidable SQL queries and keep models in sync.'
+
+    # Optimization: don't call `on_send` unless the method name is in this list
+    RESTRICT_ON_SEND = %i[has_many belongs_to].freeze
+    ASSOCIATION_METHODS = RESTRICT_ON_SEND.to_set
+
+    def_node_matcher :missing_inverse_of_no_arguments?, <<~PATTERN
+      (send nil? ASSOCIATION_METHODS (sym _))
+    PATTERN
+
+    def_node_matcher :missing_inverse_of_with_arguments?, <<~PATTERN
+      (send nil? ASSOCIATION_METHODS (sym _) (hash $...))
+    PATTERN
+
+    def on_send(node)
+      return add_offense(node) if missing_inverse_of_no_arguments?(node)
+
+      return unless (hash_pairs = missing_inverse_of_with_arguments?(node))
+
+      add_offense(node) unless contain_inverse_of?(hash_pairs)
+    end
+
+    private
+
+    def contain_inverse_of?(nodes)
+      pattern = RuboCop::NodePattern.new('(pair (sym :inverse_of) _)')
+
+      nodes.any? { pattern.match(_1) }
+    end
+  end
+end

--- a/custom_cops/spec/required_inverse_of_relations_spec.rb
+++ b/custom_cops/spec/required_inverse_of_relations_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+require 'rubocop/rspec/support'
+require_relative '../required_inverse_of_relations'
+
+RSpec.configure do |config|
+  config.include RuboCop::RSpec::ExpectOffense
+end
+
+describe CustomCops::RequiredInverseOfRelations, :config do
+  context 'given an association expression without :inverse_of option' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        class Test
+          has_many :books
+          ^^^^^^^^^^^^^^^ Use inverse_of option when defining associations to prevent avoidable SQL queries and keep models in sync.
+        end
+      RUBY
+
+      expect_offense(<<~RUBY)
+        class Test
+          belongs_to :books
+          ^^^^^^^^^^^^^^^^^ Use inverse_of option when defining associations to prevent avoidable SQL queries and keep models in sync.
+        end
+      RUBY
+    end
+  end
+
+  context 'given an association expression with :inverse_of option' do
+    it 'do NOT register any offenses' do
+      expect_no_offenses(<<~RUBY)
+        class Test
+          has_many :books, inverse_of: :author
+        end
+      RUBY
+
+      expect_no_offenses(<<~RUBY)
+        class Test
+          belongs_to :author, inverse_of: :books
+        end
+      RUBY
+    end
+  end
+end

--- a/custom_cops/spec/required_inverse_of_relations_spec.rb
+++ b/custom_cops/spec/required_inverse_of_relations_spec.rb
@@ -28,7 +28,7 @@ describe CustomCops::RequiredInverseOfRelations, :config do
   end
 
   context 'given an association expression with :inverse_of option' do
-    it 'do NOT register any offenses' do
+    it 'registers NO offenses' do
       expect_no_offenses(<<~RUBY)
         class Test
           has_many :books, inverse_of: :author
@@ -40,6 +40,32 @@ describe CustomCops::RequiredInverseOfRelations, :config do
           belongs_to :author, inverse_of: :books
         end
       RUBY
+    end
+  end
+
+  context 'given a method which have the same name with one of Rails association helpers' do
+    context 'given the method invocation has explicit module/class' do
+      it 'registers NO offenses' do
+        expect_no_offenses(<<~RUBY)
+          class Test
+            def test
+              Module.has_many :books
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'given the method invocation has explicit receiver' do
+      it 'registers NO offenses' do
+        expect_no_offenses(<<~RUBY)
+          class Test
+            def test
+              self.has_many :books
+            end
+          end
+        RUBY
+      end
     end
   end
 end

--- a/template.rb
+++ b/template.rb
@@ -103,6 +103,7 @@ def apply_optional_addons
   apply '.template/addons/nginx/template.rb' if @install_nginx
   apply '.template/addons/phrase/template.rb' if @install_phrase
   apply '.template/addons/devise/template.rb' if @install_devise
+  apply '.template/addons/custom_cops/template.rb'
 end
 
 # Set Thor::Actions source path for looking up the files


### PR DESCRIPTION
- Close #494

## What happened 👀

Implement custom cop to enforce explicit `inverse_of` when specifying Rails association
[Compass rule](https://nimblehq.co/compass/development/code-conventions/ruby/ruby-on-rails/#convention-13)

## Insight 📝

- [ ] Detect Rails model files and only run this cop on such files

There are severals trade-offs that I made to reduce the complexity of the cop:
- We can improve the performance by only scanning the top level expressions of the class. I haven't tested it yet, but I suspect that the gain would be negligible. The reason is that we use a lot of different cop rules so that there's a good chance that we have to scan the whole file anyway.
- There's no easy way to distinguish between Rails association helpers and our application functions. If the names collide, it might lead to false positive. However, in practice, we should avoid from naming our methods this way, so I think we could safely ignore this case.

```ruby
class Author < ActiveRecord::Model
  has_many :books # we should scan this one
  belongs_to :user # and this one

  def test
    SomeModule.has_many(...) # but not this one
  end
end
```

## Proof Of Work 📹

https://github.com/nimblehq/rails-templates/assets/35915460/eb7efad9-db43-4382-83e2-f63cdc08a778

