### PR TITLE
[#463] Update the branch-tag-action in the test workflow

### DIFF
--- a/.template/addons/github/.github/workflows/test.yml.tt
+++ b/.template/addons/github/.github/workflows/test.yml.tt
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set env BRANCH_TAG
-        uses: nimblehq/branch-tag-action@v1.2
+        uses: nimblehq/branch-tag-action@1
 
       - name: Login to Docker registry
         uses: docker/login-action@v2


### PR DESCRIPTION
- Close #463

## What happened 👀

Update the `branch-tag` action to use the latest minor version, `branch-tag-action@1` instead of `branch-tag-action@v1.2`

## Insight 📝

`n/a`

## Proof Of Work 📹

Just a small update, nothing special as all the CI actions passed ✅ 