### PR TITLE
[#461] Move user_email in publish_wiki workflow to a secret

### DIFF
--- a/.template/addons/github/.github/workflows/publish_wiki.yml.tt
+++ b/.template/addons/github/.github/workflows/publish_wiki.yml.tt
@@ -27,5 +27,5 @@ jobs:
         uses: nimblehq/publish-github-wiki-action@v1.0
         with:
           user_name: github-wiki-workflow
-          user_email: bot@nimblehq.co
+          user_email: ${{ secrets.USER_EMAIL }}
           user_access_token: ${{ secrets.USER_ACCESS_TOKEN }}


### PR DESCRIPTION
- Close #461

## What happened 👀

Move `user_email` in the `publish_wiki` workflow to a `secret` instead of publicizing it.

## Insight 📝

`n/a`

## Proof Of Work 📹

Just changed the usage, nothing special. 🚀 