### PR TITLE
[#482] Add the Rubocop cop to enforce YARD documentation for public methods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,9 @@ AllCops:
 Style/Documentation:
   Enabled: false
 
+Style/DocumentationMethod:
+  Enabled: true
+
 Layout/LineLength:
   Max: 130
   Exclude:

--- a/.template/addons/svgeez/helpers/svg_helper.rb
+++ b/.template/addons/svgeez/helpers/svg_helper.rb
@@ -6,6 +6,10 @@ module SvgHelper
     height: '16'
   }.freeze
 
+  # @param [Hash<String: String>] html
+  # @param [String] icon_id
+  #
+  # @return [String]
   def svg_tag(html: {}, icon_id: '')
     svg_attributes = DEFAULT_SVG_ATTRIBUTES.merge(html)
 


### PR DESCRIPTION
- Close #482

## What happened 👀

Enable the cop to enforce public methods YARD documentation.

## Insight 📝

`n/a`

## Proof Of Work 📹

The generated app passes the Rubocop check after adding the documentation to 1 public method (in the SVG helper):

<img width="420" alt="image" src="https://github.com/nimblehq/rails-templates/assets/77609814/c0d3c59d-4f40-4a72-86de-2a02320f013b">

